### PR TITLE
Change androidx.browser dependency into "api"

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -44,11 +44,12 @@ android {
 }
 
 dependencies {
+    api 'androidx.browser:browser:1.2.0-alpha07'
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.browser:browser:1.2.0-alpha07'
     implementation 'androidx.core:core:1.0.2'
 
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
PWA wrapper apps that would use this library will also have to depend on androidx.browser directly, in order to be able to refer to androidx.browser.trusted.TrustedWebActivityService in their manifest. This may be quite confusing. To avoid that, I suggest replacing "implementation" with "api" to allow transitive dependency.