### PR TITLE
Remove buildToolsVersion from library build.gradle

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -18,8 +18,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.0"
-
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
- When using Gradle 3.0 or above, it defaults to use a buildTool
  version specified by the Gradle plugin. buildToolsVersion should
  only be used in order to override the default version
- Reference: https://developer.android.com/studio/releases/build-tools
- Fixes #20 