### PR TITLE
Create DelegationService.

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/DelegationService.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/DelegationService.java
@@ -1,0 +1,24 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.trusted;
+
+import androidx.browser.trusted.TrustedWebActivityService;
+
+/**
+ * An extension of {@link TrustedWebActivityService} to allow us to extend its functionality in the
+ * future without requiring clients to change their code.
+ */
+public class DelegationService extends TrustedWebActivityService {
+}


### PR DESCRIPTION
Creates the DelegationService for clients to use/depend on. This will allow us to add to this class in the future if want to provide different behaviour than androidx.browser and will protect users from upcoming API changes around TrustedWebActivityService.