### PR TITLE
Relaunch LauncherActivity with NEW_TASK if missing.

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -113,12 +113,26 @@ public class LauncherActivity extends AppCompatActivity {
         boolean hasNewDocument = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_DOCUMENT) != 0;
 
         if (!hasNewTask || hasNewDocument) {
-            // If we're created as part of somebody else's Task, relaunch ourselves with NEW_TASK.
+            // We only want one instance of the TWA running in the user's Recent Apps. This
+            // corresponds to ensuring that the TWA only exists in a single Task.
 
-            // We need to clear NEW_DOCUMENT here as well otherwise Intents created with
-            // NEW_DOCUMENT will launch us in a new Task, separate from an existing instance (if the
-            // TWA is currently running). Setting documentLaunchMode="never" didn't stop this
-            // behaviour.
+            // If the TWA was implemented as single Activity, we could do this with
+            // launchMode=singleTask (or singleInstance), however since the TWA consists of a
+            // LauncherActivity which then starts a browser Activity, things get a bit more
+            // complicated.
+
+            // If we used singleTask on LauncherActivity then whenever a TWA was running and a new
+            // Intent was fired, the browser Activity on top would get clobbered.
+
+            // Therefore, we always ensure that LauncherActivity is launched with New Task. This
+            // means that if the TWA is already running a *new* LauncherActivity will be created on
+            // top of the Browser Activity. The browser then launches an Intent with CLEAR_TOP to
+            // the existing Browser Activity, killing the temporary LauncherActivity and focusing
+            // the TWA.
+
+            // We also need to clear NEW_DOCUMENT here as well otherwise Intents created with
+            // NEW_DOCUMENT will launch us in a new Task, separate from an existing instance.
+            // Setting documentLaunchMode="never" didn't stop this behaviour.
             Intent newIntent = new Intent(getIntent());
 
             int flags = getIntent().getFlags();

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -14,6 +14,7 @@
 
 package com.google.androidbrowserhelper.trusted;
 
+import android.content.Intent;
 import android.graphics.Matrix;
 import android.net.Uri;
 import android.os.Bundle;
@@ -107,6 +108,28 @@ public class LauncherActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        boolean hasNewTask = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != 0;
+        boolean hasNewDocument = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_DOCUMENT) != 0;
+
+        if (!hasNewTask || hasNewDocument) {
+            // If we're created as part of somebody else's Task, relaunch ourselves with NEW_TASK.
+
+            // We need to clear NEW_DOCUMENT here as well otherwise Intents created with
+            // NEW_DOCUMENT will launch us in a new Task, separate from an existing instance (if the
+            // TWA is currently running). Setting documentLaunchMode="never" didn't stop this
+            // behaviour.
+            Intent newIntent = new Intent(getIntent());
+
+            int flags = getIntent().getFlags();
+            flags |= Intent.FLAG_ACTIVITY_NEW_TASK;
+            flags &= ~Intent.FLAG_ACTIVITY_NEW_DOCUMENT;
+            newIntent.setFlags(flags);
+
+            startActivity(newIntent);
+            finish();
+            return;
+        }
 
         if (savedInstanceState != null && savedInstanceState.getBoolean(BROWSER_WAS_LAUNCHED_KEY)) {
             // This activity died in the background after launching Trusted Web Activity, then

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -109,38 +109,7 @@ public class LauncherActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        boolean hasNewTask = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != 0;
-        boolean hasNewDocument = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_DOCUMENT) != 0;
-
-        if (!hasNewTask || hasNewDocument) {
-            // We only want one instance of the TWA running in the user's Recent Apps. This
-            // corresponds to ensuring that the TWA only exists in a single Task.
-
-            // If the TWA was implemented as single Activity, we could do this with
-            // launchMode=singleTask (or singleInstance), however since the TWA consists of a
-            // LauncherActivity which then starts a browser Activity, things get a bit more
-            // complicated.
-
-            // If we used singleTask on LauncherActivity then whenever a TWA was running and a new
-            // Intent was fired, the browser Activity on top would get clobbered.
-
-            // Therefore, we always ensure that LauncherActivity is launched with New Task. This
-            // means that if the TWA is already running a *new* LauncherActivity will be created on
-            // top of the Browser Activity. The browser then launches an Intent with CLEAR_TOP to
-            // the existing Browser Activity, killing the temporary LauncherActivity and focusing
-            // the TWA.
-
-            // We also need to clear NEW_DOCUMENT here as well otherwise Intents created with
-            // NEW_DOCUMENT will launch us in a new Task, separate from an existing instance.
-            // Setting documentLaunchMode="never" didn't stop this behaviour.
-            Intent newIntent = new Intent(getIntent());
-
-            int flags = getIntent().getFlags();
-            flags |= Intent.FLAG_ACTIVITY_NEW_TASK;
-            flags &= ~Intent.FLAG_ACTIVITY_NEW_DOCUMENT;
-            newIntent.setFlags(flags);
-
-            startActivity(newIntent);
+        if (restartInNewTask()) {
             finish();
             return;
         }
@@ -273,4 +242,41 @@ public class LauncherActivity extends AppCompatActivity {
         return Uri.parse("https://www.example.com/");
     }
 
+    private boolean restartInNewTask() {
+        boolean hasNewTask = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != 0;
+        boolean hasNewDocument = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_DOCUMENT) != 0;
+
+        if (hasNewTask && !hasNewDocument) return false;
+
+        // The desired behaviour of TWAs is that there's only one running in the user's Recent
+        // Apps. This reflects how many other Android Apps work and corresponds to ensuring that
+        // the TWA only exists in a single Task.
+
+        // If the TWA was implemented as single Activity, we could do this with
+        // launchMode=singleTask (or singleInstance), however since the TWA consists of a
+        // LauncherActivity which then starts a browser Activity, things get a bit more
+        // complicated.
+
+        // If we used singleTask on LauncherActivity then whenever a TWA was running and a new
+        // Intent was fired, the browser Activity on top would get clobbered.
+
+        // Therefore, we always ensure that LauncherActivity is launched with New Task. This
+        // means that if the TWA is already running a *new* LauncherActivity will be created on
+        // top of the Browser Activity. The browser then launches an Intent with CLEAR_TOP to
+        // the existing Browser Activity, killing the temporary LauncherActivity and focusing
+        // the TWA.
+
+        // We also need to clear NEW_DOCUMENT here as well otherwise Intents created with
+        // NEW_DOCUMENT will launch us in a new Task, separate from an existing instance.
+        // Setting documentLaunchMode="never" didn't stop this behaviour.
+        Intent newIntent = new Intent(getIntent());
+
+        int flags = getIntent().getFlags();
+        flags |= Intent.FLAG_ACTIVITY_NEW_TASK;
+        flags &= ~Intent.FLAG_ACTIVITY_NEW_DOCUMENT;
+        newIntent.setFlags(flags);
+
+        startActivity(newIntent);
+        return true;
+    }
 }


### PR DESCRIPTION
I can't quite place how ugly this solution is, but it seems to work...

I've created https://github.com/GoogleChrome/android-browser-helper/issues/27 as well.