### PR TITLE
Generate Maven Artifacts

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion 28
@@ -60,4 +61,42 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-core:3.0.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.19.0'
     androidTestImplementation 'junit:junit:4.12'
+}
+
+publishing {
+    publications {
+        Production(MavenPublication) {
+            pom {
+                name = 'android-browser-helper'
+                url = 'https://github.com/GoogleChrome/android-browser-helper'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+            }
+
+            artifact("$buildDir/outputs/aar/androidbrowserhelper-release.aar")
+
+            groupId 'com.google.androidbrowserhelper'
+            artifactId 'androidbrowserhelper'
+            version '0.1.0-alpha1'
+
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+
+                // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                configurations.implementation.allDependencies.each {
+                    // Ensure dependencies such as fileTree are not included in the pom.
+                    if (it.name != 'unspecified') {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -83,10 +83,14 @@ publishing {
             artifactId 'androidbrowserhelper'
             version '0.1.0-alpha1'
 
+            // This ensures that the generated POM file contains the correct Android dependencies.
+            // The section used the BinTray example as a base:
+            // https://github.com/bintray/bintray-examples/blob/master/gradle-bintray-plugin-examples/android-gradle-3.0.0-maven-example/app/publish.gradle#L7-L31
             pom.withXml {
                 def dependenciesNode = asNode().appendNode('dependencies')
 
-                // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                // Iterate over the implementation dependencies (we don't want the test ones),
+                // adding a <dependency> node for each
                 configurations.implementation.allDependencies.each {
                     // Ensure dependencies such as fileTree are not included in the pom.
                     if (it.name != 'unspecified') {


### PR DESCRIPTION
- Modified `androidbrowserhelper/build.gradle` to generate the
   Maven artifacts required for publishing the library.