### PR TITLE
Update README with how to use the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ developer will find themselves requiring, for example:
 * Code for choosing an appropriate Custom Tabs provider.
 * Creating an Activity to launch the browser's site settings for a TWA.
 
+## Adding Android Browser Helper to an Android project
+
+Android Browser helper is available on the Google Maven. To use it, modify your application's
+`build.gradle` and add the library as a dependency, as described below:
+
+```gradle
+dependencies {
+    //...
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:0.1.0-alpha1'
+}
+
+``` 
+
+**Important:** Since Android Browser Helper depends on a version of `androidx.browser` that is not
+yet stable, the library is still marked as alpha. This will be updated once all the libraries
+it depends on are stable.
+
 ## Source Code Headers
 
 Every file containing source code must include copyright and license

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ dependencies {
 yet stable, the library is still marked as alpha. This will be updated once all the libraries
 it depends on are stable.
 
+**Warning:** Due to API changes on the latest Alpha version of `androidx.browser`, which Android
+Browser Helper depends on, the current version of Android Browser Helper, `0.1.0-alpha1`, is not
+compatible with versions of `androidx.browser` starting from `1.2.0-alpha09`. We are working
+on an `alpha2` version of Android Browser Helper, that will fix the compatibility.
+  
 ## Source Code Headers
 
 Every file containing source code must include copyright and license


### PR DESCRIPTION
- Even though the library is not stable yet, it already has a
  version available on the Google Maven. Since Android Browser
  Helper is the only way to use TWAs with AndroidX libraries,
  adding instructions for developers who want to do so, along
  with a warning on why it isn't stable yet.