### PR TITLE
Fix issue #38

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -192,6 +192,9 @@ public class TwaLauncher {
 
     private void launchWhenSplashScreenReady(TrustedWebActivityIntentBuilder builder,
             @Nullable Runnable completionCallback) {
+        if (mDestroyed) {
+            return;  // Destroyed while preparing the splash screen (e.g. user closed the app).
+        }
         Log.d(TAG, "Launching Trusted Web Activity.");
         Intent intent = builder.build(mSession);
         ContextCompat.startActivity(mContext, intent, null);
@@ -207,6 +210,9 @@ public class TwaLauncher {
      * Performs clean-up.
      */
     public void destroy() {
+        if (mDestroyed) {
+            return;
+        }
         if (mServiceConnection != null) {
             mContext.unbindService(mServiceConnection);
         }


### PR DESCRIPTION
The NPE occurs when app is closed while splash screen is being transferred. All we need to do is bail out.

It's probably conceivable that the Service connection gets destroyed by itself, but I don't think that's  actually ever happening. We can verify this by looking at crash reports.