### PR TITLE
Makes android-browser-helper compatible with androidx.browser-1.2.0

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    api 'androidx.browser:browser:1.2.0-alpha07'
+    api 'androidx.browser:browser:1.2.0'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 

--- a/androidbrowserhelper/src/androidTest/AndroidManifest.xml
+++ b/androidbrowserhelper/src/androidTest/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <application>
         <activity android:name="com.google.androidbrowserhelper.trusted.testcomponents.TestActivity"
                   android:enabled="false">
-            <!-- A browsable intent filter is required for the TrustedWebActivityService. -->
+            <!-- A browsable intent filter is required for the DelegationService. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT" />

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ChromeLegacyUtils.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ChromeLegacyUtils.java
@@ -148,6 +148,8 @@ public class ChromeLegacyUtils {
     static int getVersionCode(PackageManager pm, String packageName) {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                // getLongVersionCode contains versionCode in the lower 32bits and versionCodeMajor
+                // in the higher 32 bits. Casting to int will give us the lower 32 bits.
                 return (int) pm.getPackageInfo(packageName, 0).getLongVersionCode();
             }
             return pm.getPackageInfo(packageName, 0).versionCode;

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ChromeLegacyUtils.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ChromeLegacyUtils.java
@@ -14,6 +14,7 @@
 package com.google.androidbrowserhelper.trusted;
 
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import java.util.Arrays;
 import java.util.List;
@@ -143,8 +144,12 @@ public class ChromeLegacyUtils {
         return getVersionCode(pm, packageName) >= version;
     }
 
+    @SuppressWarnings("deprecation")
     static int getVersionCode(PackageManager pm, String packageName) {
         try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                return (int) pm.getPackageInfo(packageName, 0).getLongVersionCode();
+            }
             return pm.getPackageInfo(packageName, 0).versionCode;
         } catch (PackageManager.NameNotFoundException e) {
             return 0;

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/DelegationService.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/DelegationService.java
@@ -22,7 +22,7 @@ import androidx.browser.trusted.TokenStore;
  * {@link androidx.browser.trusted.TrustedWebActivityService#getTokenStore()} using a
  * {@link SharedPreferencesTokenStore}.
  */
-public class TrustedWebActivityService extends androidx.browser.trusted.TrustedWebActivityService {
+public class DelegationService extends androidx.browser.trusted.TrustedWebActivityService {
 
     @NonNull
     @Override

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/SharedPreferencesTokenStore.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/SharedPreferencesTokenStore.java
@@ -1,0 +1,87 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.trusted;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Base64;
+
+import androidx.annotation.Nullable;
+import androidx.browser.trusted.Token;
+import androidx.browser.trusted.TokenStore;
+
+/**
+ * Implements a {@link TokenStore} that uses {@link SharedPreferences} as the storage mechanistm
+ * for the {@link Token}.
+ */
+public class SharedPreferencesTokenStore implements TokenStore {
+    private static final String SHARED_PREFERENCES_NAME = "com.google.androidbrowserhelper";
+    private static final String KEY_TOKEN =
+            "com.google.androidbrowserhelper.trusted.SharedPreferencesTokenStore.TOKEN";
+
+    private Context mContext;
+
+    /**
+     * Creates a new SharedPreferencesTokenStore
+     *
+     * @param mContext The {@link Context} where the {@link SharedPreferences} will be stored.
+     */
+    public SharedPreferencesTokenStore(Context mContext) {
+        this.mContext = mContext;
+    }
+
+    /**
+     * This persists the given {@link Token} on a {@link SharedPreferences}.
+     * Subsequent calls will overwrite the previously given {@link Token}.
+     *
+     * @param token The token to persist. It may be {@code null} to clear the storage.
+     */
+    @Override
+    public void store(@Nullable Token token) {
+        SharedPreferences preferences =
+                mContext.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+
+        // Clear the preference if the token is null
+        if (token == null) {
+            preferences.edit().remove(KEY_TOKEN).apply();
+            return;
+        }
+
+        String encodedToken = Base64.encodeToString(token.serialize(), Base64.DEFAULT);
+        preferences.edit()
+                .putString(KEY_TOKEN, encodedToken)
+                .apply();
+    }
+
+    /**
+     * This method returns the {@link Token} previously persisted by a call to {@link #store}.
+     * @return The previously persisted {@link Token}, or {@code null} if none exist.
+     *
+     * This method will be called on a binder thread by {@link TrustedWebActivityService}.
+     */
+    @Nullable
+    @Override
+    public Token load() {
+        SharedPreferences preferences =
+                mContext.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+        String stringifiedToken = preferences.getString(KEY_TOKEN, null);
+        if (stringifiedToken == null) {
+            return null;
+        }
+
+        byte[] serializedToken = Base64.decode(stringifiedToken, Base64.DEFAULT);
+        return Token.deserialize(serializedToken);
+    }
+}

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/SharedPreferencesTokenStore.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/SharedPreferencesTokenStore.java
@@ -71,7 +71,7 @@ public class SharedPreferencesTokenStore implements TokenStore {
      * This method returns the {@link Token} previously persisted by a call to {@link #store}.
      * @return The previously persisted {@link Token}, or {@code null} if none exist.
      *
-     * This method will be called on a binder thread by {@link TrustedWebActivityService}.
+     * This method will be called on a binder thread by {@link DelegationService}.
      */
     @Nullable
     @Override

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/SharedPreferencesTokenStore.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/SharedPreferencesTokenStore.java
@@ -16,6 +16,7 @@ package com.google.androidbrowserhelper.trusted;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.util.Base64;
 
 import androidx.annotation.Nullable;
@@ -29,12 +30,12 @@ import androidx.browser.trusted.TokenStore;
 public class SharedPreferencesTokenStore implements TokenStore {
     private static final String SHARED_PREFERENCES_NAME = "com.google.androidbrowserhelper";
     private static final String KEY_TOKEN =
-            "com.google.androidbrowserhelper.trusted.SharedPreferencesTokenStore.TOKEN";
+            "SharedPreferencesTokenStore.TOKEN";
 
     private Context mContext;
 
     /**
-     * Creates a new SharedPreferencesTokenStore
+     * Creates a new SharedPreferencesTokenStore.
      *
      * @param mContext The {@link Context} where the {@link SharedPreferences} will be stored.
      */
@@ -59,7 +60,8 @@ public class SharedPreferencesTokenStore implements TokenStore {
             return;
         }
 
-        String encodedToken = Base64.encodeToString(token.serialize(), Base64.DEFAULT);
+        String encodedToken =
+                Base64.encodeToString(token.serialize(), Base64.NO_WRAP | Base64.NO_PADDING);
         preferences.edit()
                 .putString(KEY_TOKEN, encodedToken)
                 .apply();
@@ -81,7 +83,13 @@ public class SharedPreferencesTokenStore implements TokenStore {
             return null;
         }
 
-        byte[] serializedToken = Base64.decode(stringifiedToken, Base64.DEFAULT);
+        byte[] serializedToken =
+                Base64.decode(stringifiedToken, Base64.NO_WRAP | Base64.NO_PADDING);
         return Token.deserialize(serializedToken);
+    }
+
+    public void setVerifiedProvider(String providerPackage, PackageManager packageManager) {
+        Token token = Token.create(providerPackage, packageManager);
+        this.store(token);
     }
 }

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TrustedWebActivityService.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TrustedWebActivityService.java
@@ -18,8 +18,9 @@ import androidx.annotation.NonNull;
 import androidx.browser.trusted.TokenStore;
 
 /**
- * An extension of {@link androidx.browser.trusted.TrustedWebActivityService} to allow us to extend
- * its functionality in the future without requiring clients to change their code.
+ * An extension of {@link androidx.browser.trusted.TrustedWebActivityService} that implements
+ * {@link androidx.browser.trusted.TrustedWebActivityService#getTokenStore()} using a
+ * {@link SharedPreferencesTokenStore}.
  */
 public class TrustedWebActivityService extends androidx.browser.trusted.TrustedWebActivityService {
 

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TrustedWebActivityService.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TrustedWebActivityService.java
@@ -14,11 +14,18 @@
 
 package com.google.androidbrowserhelper.trusted;
 
-import androidx.browser.trusted.TrustedWebActivityService;
+import androidx.annotation.NonNull;
+import androidx.browser.trusted.TokenStore;
 
 /**
- * An extension of {@link TrustedWebActivityService} to allow us to extend its functionality in the
- * future without requiring clients to change their code.
+ * An extension of {@link androidx.browser.trusted.TrustedWebActivityService} to allow us to extend
+ * its functionality in the future without requiring clients to change their code.
  */
-public class DelegationService extends TrustedWebActivityService {
+public class TrustedWebActivityService extends androidx.browser.trusted.TrustedWebActivityService {
+
+    @NonNull
+    @Override
+    public TokenStore getTokenStore() {
+        return new SharedPreferencesTokenStore(this);
+    }
 }

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/splashscreens/PwaWrapperSplashScreenStrategy.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/splashscreens/PwaWrapperSplashScreenStrategy.java
@@ -91,9 +91,9 @@ public class PwaWrapperSplashScreenStrategy implements SplashScreenStrategy {
      * @param drawableId Resource id of the Drawable of an image (e.g. logo) displayed in the
      * splash screen.
      * @param backgroundColor Background color of the splash screen.
-     * @param scaleType see {@link SplashScreenParamKey#SCALE_TYPE}
-     * @param transformationMatrix see {@link SplashScreenParamKey#IMAGE_TRANSFORMATION_MATRIX}.
-     * @param fadeOutDurationMillis see {@link SplashScreenParamKey#FADE_OUT_DURATION_MS}.
+     * @param scaleType see {@link SplashScreenParamKey#KEY_SCALE_TYPE}
+     * @param transformationMatrix see {@link SplashScreenParamKey#KEY_IMAGE_TRANSFORMATION_MATRIX}.
+     * @param fadeOutDurationMillis see {@link SplashScreenParamKey#KEY_FADE_OUT_DURATION_MS}.
      * @param fileProviderAuthority Authority of a FileProvider used for transferring the splash
      * image to the browser.
      */
@@ -117,7 +117,7 @@ public class PwaWrapperSplashScreenStrategy implements SplashScreenStrategy {
     @Override
     public void onTwaLaunchInitiated(String providerPackage, TrustedWebActivityIntentBuilder builder) {
         mProviderPackage = providerPackage;
-        mProviderSupportsSplashScreens = TrustedWebUtils.splashScreensAreSupported(mActivity,
+        mProviderSupportsSplashScreens = TrustedWebUtils.areSplashScreensSupported(mActivity,
                 providerPackage, SplashScreenVersion.V1);
 
         if (!mProviderSupportsSplashScreens) {
@@ -221,14 +221,14 @@ public class PwaWrapperSplashScreenStrategy implements SplashScreenStrategy {
     @NonNull
     private Bundle makeSplashScreenParamsBundle() {
         Bundle bundle = new Bundle();
-        bundle.putString(SplashScreenParamKey.VERSION, SplashScreenVersion.V1);
-        bundle.putInt(SplashScreenParamKey.FADE_OUT_DURATION_MS, mFadeOutDurationMillis);
-        bundle.putInt(SplashScreenParamKey.BACKGROUND_COLOR, mBackgroundColor);
-        bundle.putInt(SplashScreenParamKey.SCALE_TYPE, mScaleType.ordinal());
+        bundle.putString(SplashScreenParamKey.KEY_VERSION, SplashScreenVersion.V1);
+        bundle.putInt(SplashScreenParamKey.KEY_FADE_OUT_DURATION_MS, mFadeOutDurationMillis);
+        bundle.putInt(SplashScreenParamKey.KEY_BACKGROUND_COLOR, mBackgroundColor);
+        bundle.putInt(SplashScreenParamKey.KEY_SCALE_TYPE, mScaleType.ordinal());
         if (mTransformationMatrix != null) {
             float[] values = new float[9];
             mTransformationMatrix.getValues(values);
-            bundle.putFloatArray(SplashScreenParamKey.IMAGE_TRANSFORMATION_MATRIX,
+            bundle.putFloatArray(SplashScreenParamKey.KEY_IMAGE_TRANSFORMATION_MATRIX,
                     values);
         }
         return bundle;

--- a/demos/twa-basic/src/main/AndroidManifest.xml
+++ b/demos/twa-basic/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
         </provider>
 
         <service
-            android:name="androidx.browser.trusted.TrustedWebActivityService"
+            android:name="com.google.androidbrowserhelper.trusted.TrustedWebActivityService"
             android:exported="true">
 
             <intent-filter>

--- a/demos/twa-basic/src/main/AndroidManifest.xml
+++ b/demos/twa-basic/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
         </provider>
 
         <service
-            android:name="com.google.androidbrowserhelper.trusted.TrustedWebActivityService"
+            android:name="com.google.androidbrowserhelper.trusted.DelegationService"
             android:exported="true">
 
             <intent-filter>

--- a/demos/twa-custom-launcher/src/main/java/com/google/androidbrowserhelper/launchtwa/LaunchTwaActivity.java
+++ b/demos/twa-custom-launcher/src/main/java/com/google/androidbrowserhelper/launchtwa/LaunchTwaActivity.java
@@ -110,7 +110,7 @@ public class LaunchTwaActivity extends AppCompatActivity {
                             "Couldn't get session from provider.", Toast.LENGTH_LONG).show();
                 }
 
-                Intent intent = builder.build(mSession);
+                Intent intent = builder.build(mSession).getIntent();
                 intent.putExtra(Intent.EXTRA_REFERRER,
                         Uri.parse("android-app://com.google.androidbrowserhelper?twa=true"));
                 startActivity(intent);

--- a/demos/twa-webview-fallback/src/main/AndroidManifest.xml
+++ b/demos/twa-webview-fallback/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
         </provider>
 
         <service
-            android:name="androidx.browser.trusted.TrustedWebActivityService"
+            android:name="com.google.androidbrowserhelper.trusted.TrustedWebActivityService"
             android:exported="true">
 
             <intent-filter>

--- a/demos/twa-webview-fallback/src/main/AndroidManifest.xml
+++ b/demos/twa-webview-fallback/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
         </provider>
 
         <service
-            android:name="com.google.androidbrowserhelper.trusted.TrustedWebActivityService"
+            android:name="com.google.androidbrowserhelper.trusted.DelegationService"
             android:exported="true">
 
             <intent-filter>

--- a/demos/twa-webview-fallback/src/main/java/com/google/browser/examples/twawebviewfallback/MyLauncherActivity.java
+++ b/demos/twa-webview-fallback/src/main/java/com/google/browser/examples/twawebviewfallback/MyLauncherActivity.java
@@ -25,7 +25,7 @@ public class MyLauncherActivity extends LauncherActivity {
     protected TwaLauncher.FallbackStrategy getFallbackStrategy() {
         return (context, twaIntentBuilder, mProviderPackage, completionCallback) -> {
             Intent intent = new Intent(context, WebViewFallbackActivity.class);
-            intent.putExtra(WebViewFallbackActivity.KEY_LAUNCH_URI, twaIntentBuilder.getUrl());
+            intent.putExtra(WebViewFallbackActivity.KEY_LAUNCH_URI, twaIntentBuilder.getUri());
             startActivity(intent);
             completionCallback.run();
         };


### PR DESCRIPTION
- Updates Key names to versions compatible with `androidx.browser`
- Implements a `TokenStore` with `SharedPreferencesTokenStore`
- Handles the deprecation of `PackageInfo.versionCode`
- Renames `DelegationService` to `TrustedWebActivityService` and
  implements `getTokenStore`
- Updates `twa-basic` and `twa-webview-fallback` to use
  `com.google.androidbrowserhelper.helper.TrustedWebActivityService`
  instead of `androidx.browser.truster.TrustedWebActivityService`

**WARNING**: This is a breaking change, due to developers having to
replace the androidx.browser TrustedWebActivityService with the
android-browser-helper TrustedWebActivityService.

Closes #48 