### PR TITLE
Fixes asset_staments on twa-multi-domain

### DIFF
--- a/demos/twa-multi-domain/README.md
+++ b/demos/twa-multi-domain/README.md
@@ -22,21 +22,21 @@ contains all origins to be validated. Example:
 ```xml
     <string name="asset_statements">
     [{
-        \"relation\": [\"delegate_permission/common.share_location\"],
+        \"relation\": [\"delegate_permission/common.handle_all_urls\"],
         \"target\": {
             \"namespace\": \"web\",
             \"site\": \"https://github.com\"
         }
     }],
     [{
-        \"relation\": [\"delegate_permission/common.share_location\"],
+        \"relation\": [\"delegate_permission/common.handle_all_urls\"],
         \"target\": {
             \"namespace\": \"web\",
             \"site\": \"https://www.google.com\"
         }
     }],
     [{
-        \"relation\": [\"delegate_permission/common.share_location\"],
+        \"relation\": [\"delegate_permission/common.handle_all_urls\"],
         \"target\": {
             \"namespace\": \"web\",
             \"site\": \"https://www.wikipedia.com\"

--- a/demos/twa-multi-domain/src/main/res/values/strings.xml
+++ b/demos/twa-multi-domain/src/main/res/values/strings.xml
@@ -23,21 +23,21 @@
     </string-array>
     <string name="asset_statements">
     [{
-        \"relation\": [\"delegate_permission/common.share_location\"],
+        \"relation\": [\"delegate_permission/common.handle_all_urls\"],
         \"target\": {
             \"namespace\": \"web\",
             \"site\": \"https://github.com\"
         }
     }],
     [{
-        \"relation\": [\"delegate_permission/common.share_location\"],
+        \"relation\": [\"delegate_permission/common.handle_all_urls\"],
         \"target\": {
             \"namespace\": \"web\",
             \"site\": \"https://www.google.com\"
         }
     }],
     [{
-        \"relation\": [\"delegate_permission/common.share_location\"],
+        \"relation\": [\"delegate_permission/common.handle_all_urls\"],
         \"target\": {
             \"namespace\": \"web\",
             \"site\": \"https://www.wikipedia.com\"


### PR DESCRIPTION
- strings.xml using common.share_location instead of
  common.handle_all_urls