### PR TITLE
Handles Service disconnection while showing the splash screen

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -232,8 +232,10 @@ public class TwaLauncher {
 
     private void launchWhenSplashScreenReady(TrustedWebActivityIntentBuilder builder,
             @Nullable Runnable completionCallback) {
-        if (mDestroyed) {
-            return;  // Destroyed while preparing the splash screen (e.g. user closed the app).
+        if (mDestroyed || mSession == null) {
+            return;  // Service was disconnected and / or TwaLauncher was destroyed while preparing
+                     // the splash screen (e.g. user closed the app). See https://crbug.com/1052367
+                     // for further details.
         }
         Log.d(TAG, "Launching Trusted Web Activity.");
         Intent intent = builder.build(mSession).getIntent();


### PR DESCRIPTION
- The Service may be disconnected while the splash screen is shown.
  the code checks if TwaLauncher was destroyed, but the code could
  be called while the service was simply disconnected and before
  destroyed was called. More information on https://crbug.com/1052367