### PR TITLE
Checks if both browser Intents and startUrls Intents are supported in providerPicker

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -159,7 +159,7 @@ public class LauncherActivity extends AppCompatActivity {
             twaBuilder.setAdditionalTrustedOrigins(mMetadata.additionalTrustedOrigins);
         }
 
-        mTwaLauncher = new TwaLauncher(this);
+        mTwaLauncher = new TwaLauncher(this, Uri.parse(mMetadata.defaultUrl));
         mTwaLauncher.launch(twaBuilder,
                 mSplashScreenStrategy,
                 () -> mBrowserWasLaunched = true,

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -119,8 +119,8 @@ public class TwaLauncher {
         mSessionId = sessionId;
         mTokenStore = tokenStore;
         if (providerPackage == null) {
-            TwaProviderPicker.Action action =
-                    TwaProviderPicker.pickProvider(context.getPackageManager());
+            TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(
+                    context.getPackageManager(), launchUri, context.getPackageName());
             mProviderPackage = action.provider;
             mLaunchMode = action.launchMode;
         } else {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -122,7 +122,7 @@ public class TwaLauncher {
         mTokenStore = tokenStore;
         if (providerPackage == null) {
             TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(
-                    context.getPackageManager(), launchUri, context.getPackageName());
+                    context.getPackageManager(), launchUri);
             mProviderPackage = action.provider;
             mLaunchMode = action.launchMode;
         } else {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -95,17 +95,18 @@ public class TwaLauncher {
      * Creates an instance that will automatically choose the browser to launch a TWA in.
      * If no browser supports TWA, will launch a usual Custom Tab (see {@link TwaProviderPicker}.
      */
-    public TwaLauncher(Context context) {
-        this(context, null);
+    public TwaLauncher(Context context, Uri launchUri) {
+        this(context, null, launchUri);
     }
 
     /**
      * Same as above, but also allows to specify a browser to launch. If specified, it is assumed to
      * support TWAs.
      */
-    public TwaLauncher(Context context, @Nullable String providerPackage) {
+    public TwaLauncher(Context context, @Nullable String providerPackage, Uri launchUri) {
         this(context, providerPackage, DEFAULT_SESSION_ID,
-                new SharedPreferencesTokenStore(context));
+                new SharedPreferencesTokenStore(context),
+                launchUri);
     }
 
     /**
@@ -113,7 +114,7 @@ public class TwaLauncher {
      * task.
      */
     public TwaLauncher(Context context, @Nullable String providerPackage, int sessionId,
-                       SharedPreferencesTokenStore tokenStore) {
+                       SharedPreferencesTokenStore tokenStore, Uri launchUri) {
         mContext = context;
         mSessionId = sessionId;
         mTokenStore = tokenStore;

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
@@ -96,16 +96,11 @@ public class TwaProviderPicker {
         }
     }
 
-    /**
-     * Chooses an appropriate provider (see class description) and the launch mode that browser
-     * supports.
-     */
-    public static Action pickProvider(PackageManager pm) {
-        // TODO(peconn): Should we use "https://" instead?
+    public static Action pickProvider(PackageManager pm, Uri dataUri) {
         Intent queryBrowsersIntent = new Intent()
                 .setAction(Intent.ACTION_VIEW)
                 .addCategory(Intent.CATEGORY_BROWSABLE)
-                .setData(Uri.parse("http://"));
+                .setData(dataUri);
 
         if (sPackageNameForTesting != null) {
             queryBrowsersIntent.setPackage(sPackageNameForTesting);
@@ -169,6 +164,15 @@ public class TwaProviderPicker {
 
         Log.d(TAG, "Found no TWA providers, using first browser: " + bestBrowserProvider);
         return new Action(LaunchMode.BROWSER, bestBrowserProvider);
+    }
+
+    /**
+     * Chooses an appropriate provider (see class description) and the launch mode that browser
+     * supports.
+     */
+    public static Action pickProvider(PackageManager pm) {
+        // TODO(peconn): Should we use "https://" instead?
+        return pickProvider(pm, Uri.parse("http://"));
     }
 
     /**

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
@@ -155,12 +155,13 @@ public class TwaProviderPicker {
      * supports.
      */
     public static Action pickProvider(
-            PackageManager pm, @Nullable Uri appStartUri, @Nullable String ownPackageName) {
+            PackageManager pm, @Nullable Uri appStartUri) {
         String bestCctProvider = null;
         String bestBrowserProvider = null;
 
         // First we query for browser applications - or applications that handle browser Intents.
-        List<ResolveInfo> possibleProviders = queryPackageManager(pm, Uri.parse("https://"));
+        // TODO(peconn): Should we use "https://" instead?
+        List<ResolveInfo> possibleProviders = queryPackageManager(pm, Uri.parse("http://"));
 
         // If a startUri is defined, we query for applications that can handle it and use the
         // intersection of both groups as handlers for this app.
@@ -173,9 +174,6 @@ public class TwaProviderPicker {
 
         for (ResolveInfo possibleProvider : possibleProviders) {
             String providerName = possibleProvider.activityInfo.packageName;
-            if (ownPackageName != null && ownPackageName.equals(providerName)) {
-                continue;
-            }
 
             @LaunchMode int launchMode = customTabsServices.containsKey(providerName)
                     ? customTabsServices.get(providerName) : LaunchMode.BROWSER;
@@ -210,7 +208,7 @@ public class TwaProviderPicker {
      * supports.
      */
     public static Action pickProvider(PackageManager pm) {
-        return pickProvider(pm, null, null);
+        return pickProvider(pm, null);
     }
 
     /**

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
@@ -96,7 +96,12 @@ public class TwaProviderPicker {
         }
     }
 
-    public static Action pickProvider(PackageManager pm, Uri dataUri) {
+    /**
+     * Chooses an appropriate provider (see class description) and the launch mode that browser
+     * supports.
+     */
+    public static Action pickProvider(
+            PackageManager pm, Uri dataUri, @Nullable String ownPackageName) {
         Intent queryBrowsersIntent = new Intent()
                 .setAction(Intent.ACTION_VIEW)
                 .addCategory(Intent.CATEGORY_BROWSABLE)
@@ -137,6 +142,9 @@ public class TwaProviderPicker {
 
         for (ResolveInfo possibleProvider : possibleProviders) {
             String providerName = possibleProvider.activityInfo.packageName;
+            if (ownPackageName != null && ownPackageName.equals(providerName)) {
+                continue;
+            }
 
             @LaunchMode int launchMode = customTabsServices.containsKey(providerName)
                     ? customTabsServices.get(providerName) : LaunchMode.BROWSER;
@@ -172,7 +180,7 @@ public class TwaProviderPicker {
      */
     public static Action pickProvider(PackageManager pm) {
         // TODO(peconn): Should we use "https://" instead?
-        return pickProvider(pm, Uri.parse("http://"));
+        return pickProvider(pm, Uri.parse("http://"), null);
     }
 
     /**

--- a/demos/twa-custom-launcher/src/main/java/com/google/androidbrowserhelper/launchtwa/LaunchTwaActivity.java
+++ b/demos/twa-custom-launcher/src/main/java/com/google/androidbrowserhelper/launchtwa/LaunchTwaActivity.java
@@ -88,7 +88,7 @@ public class LaunchTwaActivity extends AppCompatActivity {
      * @param view the source of the event invoking this method.
      */
     public void launch(View view) {
-        TwaLauncher launcher = new TwaLauncher(this);
+        TwaLauncher launcher = new TwaLauncher(this, LAUNCH_URI);
         launcher.launch(LAUNCH_URI);
         launchers.add(launcher);
     }
@@ -105,7 +105,7 @@ public class LaunchTwaActivity extends AppCompatActivity {
                 .setToolbarColor(Color.BLUE);
 
 
-        TwaLauncher launcher = new TwaLauncher(this);
+        TwaLauncher launcher = new TwaLauncher(this, LAUNCH_URI);
         launcher.launch(builder, null, null);
         launchers.add(launcher);
     }
@@ -125,7 +125,7 @@ public class LaunchTwaActivity extends AppCompatActivity {
                 .setAdditionalTrustedOrigins(origins);
 
 
-        TwaLauncher launcher = new TwaLauncher(this);
+        TwaLauncher launcher = new TwaLauncher(this, LAUNCH_URI);
         launcher.launch(builder, null, null);
         launchers.add(launcher);
     }


### PR DESCRIPTION
- It seems some apps advertise themselves as handling http and https schemes, but Android fails to launch the Activity. See #89
- This PR changes the provider picking logic, so that both browser Intents (http) and app specific Intents (https://example.com) are checked and providerPicker only returns the provider if both are supported.
