### PR TITLE
TwaProviderPicker ignores non-browsers

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -82,7 +82,7 @@ public class TwaLauncher {
     @Nullable
     private CustomTabsSession mSession;
 
-    private SharedPreferencesTokenStore mTokenStore;
+    private TokenStore mTokenStore;
 
     private boolean mDestroyed;
 

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
@@ -101,12 +101,12 @@ public class TwaProviderPicker {
      * supports.
      */
     public static Action pickProvider(PackageManager pm) {
-        // TODO(peconn): Should we use "https://" instead?
+        // Setting the Intent Data as seen at
+        // https://cs.android.com/android/platform/superproject/+/master:packages/apps/PermissionController/src/com/android/packageinstaller/role/model/BrowserRoleBehavior.java
         Intent queryBrowsersIntent = new Intent()
                 .setAction(Intent.ACTION_VIEW)
                 .addCategory(Intent.CATEGORY_BROWSABLE)
-                .setData(Uri.parse("http://"));
-
+                .setData(Uri.fromParts("http", "", null));
         if (sPackageNameForTesting != null) {
             queryBrowsersIntent.setPackage(sPackageNameForTesting);
         }

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaProviderPicker.java
@@ -102,7 +102,7 @@ public class TwaProviderPicker {
      */
     public static Action pickProvider(PackageManager pm) {
         // Setting the Intent Data as seen at
-        // https://cs.android.com/android/platform/superproject/+/master:packages/apps/PermissionController/src/com/android/packageinstaller/role/model/BrowserRoleBehavior.java
+        // https://cs.android.com/android/platform/superproject/+/fd994cf9ef8207ad03dc3a1d831e9263ddfd4469:packages/apps/PermissionController/src/com/android/packageinstaller/role/model/BrowserRoleBehavior.java
         Intent queryBrowsersIntent = new Intent()
                 .setAction(Intent.ACTION_VIEW)
                 .addCategory(Intent.CATEGORY_BROWSABLE)

--- a/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/TwaProviderPickerTest.java
+++ b/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/TwaProviderPickerTest.java
@@ -179,9 +179,49 @@ public class TwaProviderPickerTest {
         assertEquals(TWA_PROVIDER1, action.provider);
     }
 
-    private void installBrowser(String packageName) {
+    /**
+     * Tests that if an app that handles http:// but is not a browser is ignored.
+     */
+    @Test
+    public void ignoresNonBrowser() {
+        installNonBrowser(BROWSER1);
+
+        TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
+
+        assertEquals(TwaProviderPicker.LaunchMode.BROWSER, action.launchMode);
+        assertNull(action.provider);
+    }
+
+    /**
+     * Tests that if an app that is a browser is preferred over an app that handles http://
+     * but is not a browser.
+     */
+    @Test
+    public void choosesBrowserOverNonBrowser() {
+        installNonBrowser(BROWSER1);
+        installBrowser(BROWSER2);
+
+        TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
+
+        assertEquals(TwaProviderPicker.LaunchMode.BROWSER, action.launchMode);
+        assertEquals(BROWSER2, action.provider);
+    }
+
+    private void installNonBrowser(String packageName) {
         Intent intent = new Intent()
                 .setData(Uri.parse("http://"))
+                .setAction(Intent.ACTION_VIEW)
+                .addCategory(Intent.CATEGORY_BROWSABLE);
+        ResolveInfo resolveInfo = new ResolveInfo();
+        resolveInfo.activityInfo = new ActivityInfo();
+        resolveInfo.activityInfo.packageName = packageName;
+
+        mShadowPackageManager.addResolveInfoForIntent(intent, resolveInfo);
+    }
+
+    private void installBrowser(String packageName) {
+        Intent intent = new Intent()
+                .setData(Uri.fromParts("http", "", null))
                 .setAction(Intent.ACTION_VIEW)
                 .addCategory(Intent.CATEGORY_BROWSABLE);
 


### PR DESCRIPTION
- Some applications seem to declare handling Intents for http://
- Changed the browser detection as seen on https://cs.android.com/android/platform/superproject/+/master:packages/apps/PermissionController/src/com/android/packageinstaller/role/model/BrowserRoleBehavior.java
- Added tests for those cases