### PR TITLE
Make the library compatible with Android 11

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -18,11 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.3.1-alpha01"
 

--- a/androidbrowserhelper/src/main/AndroidManifest.xml
+++ b/androidbrowserhelper/src/main/AndroidManifest.xml
@@ -15,4 +15,12 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.androidbrowserhelper" />
+    package="com.google.androidbrowserhelper">
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+</manifest>

--- a/demos/twa-basic/build.gradle
+++ b/demos/twa-basic/build.gradle
@@ -17,13 +17,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.2"
 
     defaultConfig {
         applicationId "com.google.browser.examples.twa_basic"
         minSdkVersion 26
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }

--- a/demos/twa-custom-launcher/build.gradle
+++ b/demos/twa-custom-launcher/build.gradle
@@ -17,12 +17,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.0"
+    compileSdkVersion 30
+    buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "com.google.androidbrowserhelper"
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/demos/twa-multi-domain/build.gradle
+++ b/demos/twa-multi-domain/build.gradle
@@ -17,14 +17,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.0"
+    compileSdkVersion 30
+    buildToolsVersion "29.0.2"
 
 
     defaultConfig {
         applicationId "com.google.browser.examples.twa_multi_domain"
         minSdkVersion 26
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }

--- a/demos/twa-notification-delegation/build.gradle
+++ b/demos/twa-notification-delegation/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.2"
 
     defaultConfig {
         applicationId "com.google.browser.examples.twa_notification_delegation"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }

--- a/demos/twa-webview-fallback/build.gradle
+++ b/demos/twa-webview-fallback/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.2"
 
 
     defaultConfig {
         applicationId "com.google.browser.examples.twawebviewfallback"
         minSdkVersion 26
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
- Adds a `queries` section to the library `AndroidManifest.xml`
  that is automatically merged with the manifest for applications
  using the library.
- Updates Trusted Web Activity demos to target API level 30
- Doesn't update the Billing demo and the Custom Tabs demos. Those
  will be updated separately.

Closes #112 