### PR TITLE
Checks for CrOS TWA requirements

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -54,7 +54,8 @@ public class TwaLauncher {
             intent.intent.setPackage(providerPackage);
         }
         // Add the TWA flag to the intent if the app is running on ARC++ on Chrome OS.
-        if (context.getPackageManager().hasSystemFeature(ARC_FEATURE)) {
+        if (context.getPackageManager().hasSystemFeature(ARC_FEATURE) &&
+                Utils.hasChromeOsSupport(context)) {
             intent.intent.putExtra(TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true);
         }
         intent.launchUrl(context, twaBuilder.getUri());

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -52,7 +52,7 @@ public class TwaLauncher {
             intent.intent.setPackage(providerPackage);
         }
         // Add the TWA flag to the intent if the app is running on ARC++ on Chrome OS.
-        if (Utils.hasChromeOsSupport(context)) {
+        if (Utils.shouldAddExtraForChromeOs(context)) {
             intent.intent.putExtra(TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true);
         }
         intent.launchUrl(context, twaBuilder.getUri());

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -43,8 +43,6 @@ public class TwaLauncher {
 
     private static final int DEFAULT_SESSION_ID = 96375;
 
-    private static final String ARC_FEATURE = "org.chromium.arc";
-
     public static final FallbackStrategy CCT_FALLBACK_STRATEGY =
             (context, twaBuilder, providerPackage, completionCallback) -> {
         // CustomTabsIntent will fall back to launching the Browser if there are no Custom Tabs
@@ -54,8 +52,7 @@ public class TwaLauncher {
             intent.intent.setPackage(providerPackage);
         }
         // Add the TWA flag to the intent if the app is running on ARC++ on Chrome OS.
-        if (context.getPackageManager().hasSystemFeature(ARC_FEATURE) &&
-                Utils.hasChromeOsSupport(context)) {
+        if (Utils.hasChromeOsSupport(context)) {
             intent.intent.putExtra(TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true);
         }
         intent.launchUrl(context, twaBuilder.getUri());

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/Utils.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/Utils.java
@@ -105,11 +105,13 @@ public class Utils {
     }
 
     /**
-     * Verifies if the application has the required meta-tag, `web_manifest_url`, and the
-     * `web_app_manifest.json` file, required to enable the Trusted Web Activity on Chrome OS.
+     * Verifies if the application is running on Chrome OS by checking the the system feature
+     * `org.chromium.arc`. If the application is indeed running on Chrome OS, checks if it has the
+     * required meta-tag, `web_manifest_url`, and the `web_app_manifest.json` file, which are
+     * required to enable the Trusted Web Activity on Chrome OS.
      * Important: The content the meta-tag and the JSON fire are not validated.
      */
-    public static boolean hasChromeOsSupport(Context context) {
+    public static boolean shouldAddExtraForChromeOs(Context context) {
         PackageManager packageManager = context.getPackageManager();
 
         // Check if the application is running on a Chrome OS device.


### PR DESCRIPTION
- Checks the application for the requirements of running on Chrome OS.
- Prints log messages when those are missing.

The existence of `web-manifest-json` and the `web-manifest-url` meta tag indicates the app is intended to be used as a Trusted Web Activity in Chrome OS. If one of the two is not available, this PR makes the app print a message to the log and doesn't add the `EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY` extra. 
