### PR TITLE
Add site settings shortcut to supporting twa's

### DIFF
--- a/androidbrowserhelper/src/androidTest/AndroidManifest.xml
+++ b/androidbrowserhelper/src/androidTest/AndroidManifest.xml
@@ -16,7 +16,31 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="android.support.customtabs">
     <uses-sdk android:minSdkVersion="16"/>
-    <application>
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+
+            <category android:name="android.intent.category.BROWSABLE" />
+
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+    </queries>
+
+    <application
+        android:manageSpaceActivity="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
+
+        <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
+            <meta-data
+                android:name="android.support.customtabs.trusted.MANAGE_SPACE_URL"
+                android:value="https://www.test.com/default_url/" />
+            <intent-filter>
+                <action android:name="android.support.customtabs.action.ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA"/>
+            </intent-filter>
+        </activity>
+
         <activity android:name="com.google.androidbrowserhelper.trusted.testcomponents.TestActivity"
                   android:enabled="false">
             <!-- A browsable intent filter is required for the DelegationService. -->
@@ -47,6 +71,7 @@
                 <action android:name="android.support.customtabs.action.CustomTabsService" />
                 <category android:name="androidx.browser.trusted.category.TrustedWebActivities" />
                 <category android:name="androidx.browser.trusted.category.TrustedWebActivitySplashScreensV1" />
+                <category android:name="androidx.browser.trusted.category.LaunchSiteSettings" />
             </intent-filter>
         </service>
 

--- a/androidbrowserhelper/src/androidTest/AndroidManifest.xml
+++ b/androidbrowserhelper/src/androidTest/AndroidManifest.xml
@@ -36,9 +36,6 @@
             <meta-data
                 android:name="android.support.customtabs.trusted.MANAGE_SPACE_URL"
                 android:value="https://www.test.com/default_url/" />
-            <intent-filter>
-                <action android:name="android.support.customtabs.action.ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA"/>
-            </intent-filter>
         </activity>
 
         <activity android:name="com.google.androidbrowserhelper.trusted.testcomponents.TestActivity"
@@ -108,6 +105,12 @@
             <meta-data
                 android:name="android.support.customtabs.trusted.STATUS_BAR_COLOR"
                 android:resource="@color/status_bar_color" />
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
 
         <!-- For TWA splash screens -->

--- a/androidbrowserhelper/src/androidTest/AndroidManifest.xml
+++ b/androidbrowserhelper/src/androidTest/AndroidManifest.xml
@@ -16,18 +16,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="android.support.customtabs">
     <uses-sdk android:minSdkVersion="16"/>
-    <queries>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-
-            <category android:name="android.intent.category.BROWSABLE" />
-
-            <data android:scheme="https" />
-        </intent>
-        <intent>
-            <action android:name="android.support.customtabs.action.CustomTabsService" />
-        </intent>
-    </queries>
 
     <application
         android:manageSpaceActivity="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">

--- a/androidbrowserhelper/src/androidTest/AndroidManifest.xml
+++ b/androidbrowserhelper/src/androidTest/AndroidManifest.xml
@@ -17,8 +17,7 @@
           package="android.support.customtabs">
     <uses-sdk android:minSdkVersion="16"/>
 
-    <application
-        android:manageSpaceActivity="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
+    <application>
 
         <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
             <meta-data

--- a/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/LauncherActivityTest.java
+++ b/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/LauncherActivityTest.java
@@ -118,7 +118,6 @@ public class LauncherActivityTest {
         assertEquals(SITE_SETTINGS_SHORTCUT_ID, shortcutManager.getDynamicShortcuts().get(0).getId());
     }
 
-
     private void checkColor(TestBrowser browser) {
         int requestedColor = browser.getIntent()
                 .getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0);

--- a/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/LauncherActivityTest.java
+++ b/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/LauncherActivityTest.java
@@ -14,19 +14,16 @@
 
 package com.google.androidbrowserhelper.trusted;
 
-import static com.google.androidbrowserhelper.trusted.testutils.TestUtil.getBrowserActivityWhenLaunched;
+import static com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity.SITE_SETTINGS_SHORTCUT_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import static androidx.browser.customtabs.TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY;
-
 import android.content.Context;
-import android.content.Intent;
 import android.content.pm.ShortcutManager;
 import android.net.Uri;
 
 import com.google.androidbrowserhelper.test.R;
-import com.google.androidbrowserhelper.trusted.testcomponents.TestActivity;
 import com.google.androidbrowserhelper.trusted.testutils.EnableComponentsTestRule;
 import com.google.androidbrowserhelper.trusted.testcomponents.TestBrowser;
 import com.google.androidbrowserhelper.trusted.testcomponents.TestCustomTabsService;
@@ -38,10 +35,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
 import androidx.browser.customtabs.CustomTabsIntent;
-import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
 import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
@@ -119,14 +114,10 @@ public class LauncherActivityTest {
     public void addsSiteSettingsShortcut() {
         TestBrowser browser = launch();
         ShortcutManager shortcutManager = mContext.getSystemService(ShortcutManager.class);
-        shortcutManager.getDynamicShortcuts();
-        Uri url = Uri.parse("https://padr31.github.io/");
-
-        TrustedWebActivityIntentBuilder builder = new TrustedWebActivityIntentBuilder(url);
-        Runnable launchRunnable = () -> new TwaLauncher(mActivityTestRule.getActivity()).launch(builder, null, null);
-        Intent intent = getBrowserActivityWhenLaunched(launchRunnable).getIntent();
-        //browser.get
+        assertEquals(1, shortcutManager.getDynamicShortcuts().size());
+        assertEquals(SITE_SETTINGS_SHORTCUT_ID, shortcutManager.getDynamicShortcuts().get(0).getId());
     }
+
 
     private void checkColor(TestBrowser browser) {
         int requestedColor = browser.getIntent()

--- a/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/LauncherActivityTest.java
+++ b/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/LauncherActivityTest.java
@@ -14,15 +14,19 @@
 
 package com.google.androidbrowserhelper.trusted;
 
+import static com.google.androidbrowserhelper.trusted.testutils.TestUtil.getBrowserActivityWhenLaunched;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import static androidx.browser.customtabs.TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY;
 
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ShortcutManager;
 import android.net.Uri;
 
 import com.google.androidbrowserhelper.test.R;
+import com.google.androidbrowserhelper.trusted.testcomponents.TestActivity;
 import com.google.androidbrowserhelper.trusted.testutils.EnableComponentsTestRule;
 import com.google.androidbrowserhelper.trusted.testcomponents.TestBrowser;
 import com.google.androidbrowserhelper.trusted.testcomponents.TestCustomTabsService;
@@ -34,8 +38,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
 import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
@@ -107,6 +113,19 @@ public class LauncherActivityTest {
         TestBrowser browser = launch();
 
         checkColor(browser);
+    }
+
+    @Test
+    public void addsSiteSettingsShortcut() {
+        TestBrowser browser = launch();
+        ShortcutManager shortcutManager = mContext.getSystemService(ShortcutManager.class);
+        shortcutManager.getDynamicShortcuts();
+        Uri url = Uri.parse("https://padr31.github.io/");
+
+        TrustedWebActivityIntentBuilder builder = new TrustedWebActivityIntentBuilder(url);
+        Runnable launchRunnable = () -> new TwaLauncher(mActivityTestRule.getActivity()).launch(builder, null, null);
+        Intent intent = getBrowserActivityWhenLaunched(launchRunnable).getIntent();
+        //browser.get
     }
 
     private void checkColor(TestBrowser browser) {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ChromeLegacyUtils.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ChromeLegacyUtils.java
@@ -108,6 +108,14 @@ public class ChromeLegacyUtils {
     }
 
     /**
+     * Whether the browser supports site settings. Note that in legacy Chrome this coincides
+     * with supporting Trusted Web Activities.
+     */
+    public static boolean supportsSiteSettings(PackageManager packageManager, String packageName) {
+        return supportsTrustedWebActivities(packageManager, packageName);
+    }
+
+    /**
      * Returns whether {@link CustomTabsClient#warmup} needs to be called prior to launching a
      * Trusted Web Activity. Starting from version 73 Chrome does not require warmup, which allows
      * to launch Trusted Web Activities faster.

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -15,12 +15,8 @@
 package com.google.androidbrowserhelper.trusted;
 
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ShortcutInfo;
-import android.content.pm.ShortcutManager;
 import android.graphics.Matrix;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.ImageView;
@@ -36,9 +32,6 @@ import androidx.browser.trusted.TrustedWebActivityService;
 import androidx.core.content.ContextCompat;
 
 import com.google.androidbrowserhelper.trusted.splashscreens.PwaWrapperSplashScreenStrategy;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
  * A convenience class to make using Trusted Web Activities easier. You can extend this class for
@@ -177,39 +170,8 @@ public class LauncherActivity extends AppCompatActivity {
         new TwaSharedPreferencesManager(this)
                 .writeLastLaunchedProviderPackageName(mTwaLauncher.getProviderPackage());
 
-        addSiteSettingsShortcut();
-    }
-
-    /**
-     * Adds dynamic shortcut to site settings if the twa provider and android version supports it.
-     *
-     * Removes previously added site settings shortcut if it is no longer supported, e.g. the user
-     * changed their default browser.
-     */
-    private void addSiteSettingsShortcut() {
-        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) return;
-
-        PackageManager packageManager = getPackageManager();
-        ShortcutManager shortcutManager = getSystemService(ShortcutManager.class);
-
-        // Remove potentially existing shortcut if package does not support shortcuts.
-        if (!ManageDataLauncherActivity
-                .packageSupportsSiteSettings(mTwaLauncher.getProviderPackage(), packageManager)) {
-            shortcutManager.removeDynamicShortcuts(List.of(ManageDataLauncherActivity
-                    .SITE_SETTINGS_SHORTCUT_ID));
-            return;
-        }
-
-        ShortcutInfo shortcut = ManageDataLauncherActivity.getSiteSettingsShortcutOrNull(
-                this, packageManager);
-
-        // Remove potentially existing shortcut if shortcut can not be retrieved.
-        if(shortcut == null) {
-            shortcutManager.removeDynamicShortcuts(List.of(ManageDataLauncherActivity
-                    .SITE_SETTINGS_SHORTCUT_ID));
-            return;
-        };
-        shortcutManager.addDynamicShortcuts(Collections.singletonList(shortcut));
+        ManageDataLauncherActivity.addSiteSettingsShortcut(this,
+                mTwaLauncher.getProviderPackage());
     }
 
     private boolean splashScreenNeeded() {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -182,6 +182,9 @@ public class LauncherActivity extends AppCompatActivity {
 
     /**
      * Adds dynamic shortcut to site settings if the twa provider and android version supports it.
+     *
+     * Removes previously added site settings shortcut if it is no longer supported, e.g. the user
+     * changed their default browser.
      */
     private void addSiteSettingsShortcut() {
         if(Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) return;

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
@@ -338,7 +338,6 @@ public class ManageDataLauncherActivity extends AppCompatActivity {
         siteSettingsIntent.setAction(ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA);
         List<ResolveInfo> activities = packageManager.queryIntentActivities(siteSettingsIntent,
                 PackageManager.MATCH_DEFAULT_ONLY);
-        // Intent for managing settings available
         if(activities.size() > 0) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
                 return new ShortcutInfo.Builder(context, ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA)

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
@@ -343,7 +343,6 @@ public class ManageDataLauncherActivity extends AppCompatActivity {
                 return new ShortcutInfo.Builder(context, SITE_SETTINGS_SHORTCUT_ID)
                         .setShortLabel("Site Settings")
                         .setLongLabel("Manage website notifications, permissions, etc.")
-                        .setActivity(new ComponentName(context, ManageDataLauncherActivity.class))
                         .setIcon(Icon.createWithResource(context,
                                 android.R.drawable.ic_menu_preferences))
                         .setIntent(siteSettingsIntent)

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
@@ -340,8 +340,10 @@ public class ManageDataLauncherActivity extends AppCompatActivity {
      * MAIN action and LAUNCHER category in order to attach the shortcut.
      */
     @Nullable
-    public static ShortcutInfo getSiteSettingsShortcutOrNull(Context context,
+    static ShortcutInfo getSiteSettingsShortcutOrNull(Context context,
             PackageManager packageManager) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) return null;
+
         Intent siteSettingsIntent = new Intent(context, ManageDataLauncherActivity.class);
         siteSettingsIntent.setAction(ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA);
         List<ResolveInfo> activities = packageManager.queryIntentActivities(siteSettingsIntent,
@@ -349,17 +351,13 @@ public class ManageDataLauncherActivity extends AppCompatActivity {
 
         if(activities.size() == 0) return null;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            return new ShortcutInfo.Builder(context, SITE_SETTINGS_SHORTCUT_ID)
-                    .setShortLabel("Site Settings")
-                    .setLongLabel("Manage website notifications, permissions, etc.")
-                    .setIcon(Icon.createWithResource(context,
-                            android.R.drawable.ic_menu_preferences))
-                    .setIntent(siteSettingsIntent)
-                    .build();
-        }
-
-        return null;
+        return new ShortcutInfo.Builder(context, SITE_SETTINGS_SHORTCUT_ID)
+                .setShortLabel("Site Settings")
+                .setLongLabel("Manage website notifications, permissions, etc.")
+                .setIcon(Icon.createWithResource(context,
+                        android.R.drawable.ic_menu_preferences))
+                .setIntent(siteSettingsIntent)
+                .build();
     }
 
     /**

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
@@ -340,9 +340,10 @@ public class ManageDataLauncherActivity extends AppCompatActivity {
                 PackageManager.MATCH_DEFAULT_ONLY);
         if(activities.size() > 0) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-                return new ShortcutInfo.Builder(context, ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA)
+                return new ShortcutInfo.Builder(context, SITE_SETTINGS_SHORTCUT_ID)
                         .setShortLabel("Site Settings")
                         .setLongLabel("Manage website notifications, permissions, etc.")
+                        .setActivity(new ComponentName(context, ManageDataLauncherActivity.class))
                         .setIcon(Icon.createWithResource(context,
                                 android.R.drawable.ic_menu_preferences))
                         .setIntent(siteSettingsIntent)

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
@@ -20,7 +20,6 @@ import static androidx.browser.customtabs.CustomTabsService.RELATION_HANDLE_ALL_
 import static androidx.browser.customtabs.CustomTabsService.TRUSTED_WEB_ACTIVITY_CATEGORY;
 
 import android.app.Activity;
-import android.app.ActivityManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -29,7 +28,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Gravity;
@@ -76,6 +74,9 @@ public class ManageDataLauncherActivity extends AppCompatActivity {
     // TODO: move to AndroidX.
     public static final String ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA =
             "android.support.customtabs.action.ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA";
+
+    public static final String CATEGORY_LAUNCH_SITE_SETTINGS =
+            "androidx.browser.trusted.category.LaunchSiteSettings";
 
     @Nullable
     private String mProviderPackage;
@@ -294,4 +295,21 @@ public class ManageDataLauncherActivity extends AppCompatActivity {
         @Override
         public void onServiceDisconnected(ComponentName componentName) {}
     }
+
+    public static boolean packageSupportsSiteSettings(String packageName, PackageManager packageManager) {
+        if (packageName != null) {
+            if (ChromeLegacyUtils.supportsTrustedWebActivities(packageManager, packageName)) {
+                // Chrome 72-74 support site settings but don't yet have the category
+                return true;
+            } else {
+                Intent customTabsIntent = new Intent(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
+                customTabsIntent.addCategory(CATEGORY_LAUNCH_SITE_SETTINGS);
+                customTabsIntent.setPackage(packageName);
+                List<ResolveInfo> services = packageManager.queryIntentServices(customTabsIntent, PackageManager.GET_RESOLVED_FILTER);
+                return services.size() > 0;
+            }
+        }
+        return false;
+    }
 }
+

--- a/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivityTest.java
+++ b/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivityTest.java
@@ -1,0 +1,203 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.trusted;
+
+import static com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity.ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA;
+import static com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity.CATEGORY_LAUNCH_SITE_SETTINGS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
+
+import static androidx.browser.customtabs.CustomTabsService.TRUSTED_WEB_ACTIVITY_CATEGORY;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.content.pm.ServiceInfo;
+import android.net.Uri;
+import android.os.Build;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.internal.DoNotInstrument;
+import org.robolectric.shadows.ShadowPackageManager;
+
+import androidx.browser.customtabs.CustomTabsService;
+import androidx.test.InstrumentationRegistry;
+
+/**
+ * Tests for {@link TwaProviderPicker}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@DoNotInstrument
+@Config(manifest = Config.NONE)
+public class ManageDataLauncherActivityTest {
+    private PackageManager mPackageManager;
+    private ShadowPackageManager mShadowPackageManager;
+
+    private static final String TWA_PROVIDER_PACKAGE = "com.trustedweb.one";
+    private static final String CHROME = "com.android.chrome";
+    private static final int CHROME_72_VERSION = 362600000;
+    private static final int CHROME_71_VERSION = 357800000;
+
+    @Before
+    public void setUp() {
+        mPackageManager = RuntimeEnvironment.application.getPackageManager();
+        mShadowPackageManager = shadowOf(mPackageManager);
+    }
+
+    @Test
+    public void chrome72SupportsSiteSettings() {
+        installChrome(CHROME_72_VERSION);
+        TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
+
+        assertTrue(ManageDataLauncherActivity.packageSupportsSiteSettings(action.provider, mPackageManager));
+    }
+
+    @Test
+    public void chrome71DoesNotSupportsSiteSettings() {
+        installChrome(CHROME_71_VERSION);
+        TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
+
+        assertFalse(ManageDataLauncherActivity.packageSupportsSiteSettings(action.provider, mPackageManager));
+    }
+
+    @Test
+    public void browserWithCategorySupportsSiteSettings() {
+        installTrustedWebActivityProviderWithSiteSettingsCategory(TWA_PROVIDER_PACKAGE);
+
+        TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
+
+        assertTrue(ManageDataLauncherActivity.packageSupportsSiteSettings(action.provider, mPackageManager));
+    }
+
+    @Test
+    public void browserWithoutCategorySupportsSiteSettings() {
+        installTrustedWebActivityProvider(TWA_PROVIDER_PACKAGE);
+
+        TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
+
+        assertFalse(ManageDataLauncherActivity.packageSupportsSiteSettings(action.provider, mPackageManager));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N_MR1)
+    public void returnsSiteSettingsShortcut() {
+        installTrustedWebActivityProviderWithManageDataAction(TWA_PROVIDER_PACKAGE);
+
+        assertNotNull(ManageDataLauncherActivity.getSiteSettingsShortcutOrNull(mContext, mPackageManager));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void returnsNullSiteSettingsShortcutWithLowSDK() {
+        installTrustedWebActivityProviderWithManageDataAction(TWA_PROVIDER_PACKAGE);
+
+        assertNull(ManageDataLauncherActivity.getSiteSettingsShortcutOrNull(mContext, mPackageManager));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N_MR1)
+    public void returnsNullSiteSettingsShortcutWhenMissingManageDataLauncherActivity() {
+        assertNull(ManageDataLauncherActivity.getSiteSettingsShortcutOrNull(mContext, mPackageManager));
+    }
+
+    private void installBrowser(String packageName) {
+        Intent intent = new Intent()
+                .setData(Uri.fromParts("http", "", null))
+                .setAction(Intent.ACTION_VIEW)
+                .addCategory(Intent.CATEGORY_BROWSABLE);
+
+        ResolveInfo resolveInfo = new ResolveInfo();
+        resolveInfo.activityInfo = new ActivityInfo();
+        resolveInfo.activityInfo.packageName = packageName;
+
+        mShadowPackageManager.addResolveInfoForIntent(intent, resolveInfo);
+    }
+
+    private void installCustomTabsProvider(String packageName) {
+        installBrowser(packageName);
+
+        Intent intent = new Intent()
+                .setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
+
+        ResolveInfo resolveInfo = new ResolveInfo();
+        resolveInfo.serviceInfo = new ServiceInfo();
+        resolveInfo.serviceInfo.packageName = packageName;
+
+        mShadowPackageManager.addResolveInfoForIntent(intent, resolveInfo);
+    }
+
+    private void installTrustedWebActivityProvider(String packageName) {
+        installBrowser(packageName);
+
+        Intent intent = new Intent()
+                .setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
+
+        ResolveInfo resolveInfo = new ResolveInfo();
+        resolveInfo.serviceInfo = new ServiceInfo();
+        resolveInfo.serviceInfo.packageName = packageName;
+        resolveInfo.filter = Mockito.mock(IntentFilter.class);
+        when(resolveInfo.filter.hasCategory(eq(TRUSTED_WEB_ACTIVITY_CATEGORY))).thenReturn(true);
+
+        mShadowPackageManager.addResolveInfoForIntent(intent, resolveInfo);
+    }
+
+    private void installTrustedWebActivityProviderWithSiteSettingsCategory(String packageName) {
+        installBrowser(packageName);
+
+        Intent intent = new Intent()
+                .setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
+        intent.setPackage(packageName);
+        intent.addCategory(CATEGORY_LAUNCH_SITE_SETTINGS);
+
+        mShadowPackageManager.addResolveInfoForIntent(intent, new ResolveInfo());
+    }
+
+    private Context mContext = InstrumentationRegistry.getContext();
+
+    private void installTrustedWebActivityProviderWithManageDataAction(String packageName) {
+        installBrowser(packageName);
+
+        Intent intent = new Intent(mContext, ManageDataLauncherActivity.class)
+                .setAction(ACTION_MANAGE_TRUSTED_WEB_ACTIVITY_DATA);
+
+        mShadowPackageManager.addResolveInfoForIntent(intent, new ResolveInfo());
+    }
+
+    private void installChrome(int version) {
+        // Chrome was still a Custom Tabs provider before Chrome 72.
+        installCustomTabsProvider(CHROME);
+
+        PackageInfo packageInfo = new PackageInfo();
+        packageInfo.versionCode = version;
+        packageInfo.packageName = CHROME;
+
+        mShadowPackageManager.addPackage(packageInfo);
+    }
+}

--- a/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivityTest.java
+++ b/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivityTest.java
@@ -76,7 +76,8 @@ public class ManageDataLauncherActivityTest {
         installChrome(CHROME_72_VERSION);
         TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
 
-        assertTrue(ManageDataLauncherActivity.packageSupportsSiteSettings(action.provider, mPackageManager));
+        assertTrue(ManageDataLauncherActivity
+                .packageSupportsSiteSettings(action.provider, mPackageManager));
     }
 
     @Test
@@ -84,7 +85,8 @@ public class ManageDataLauncherActivityTest {
         installChrome(CHROME_71_VERSION);
         TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
 
-        assertFalse(ManageDataLauncherActivity.packageSupportsSiteSettings(action.provider, mPackageManager));
+        assertFalse(ManageDataLauncherActivity
+                .packageSupportsSiteSettings(action.provider,mPackageManager));
     }
 
     @Test
@@ -93,16 +95,18 @@ public class ManageDataLauncherActivityTest {
 
         TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
 
-        assertTrue(ManageDataLauncherActivity.packageSupportsSiteSettings(action.provider, mPackageManager));
+        assertTrue(ManageDataLauncherActivity
+                .packageSupportsSiteSettings(action.provider, mPackageManager));
     }
 
     @Test
-    public void browserWithoutCategorySupportsSiteSettings() {
+    public void browserWithoutCategoryDoesNotSupportSiteSettings() {
         installTrustedWebActivityProvider(TWA_PROVIDER_PACKAGE);
 
         TwaProviderPicker.Action action = TwaProviderPicker.pickProvider(mPackageManager);
 
-        assertFalse(ManageDataLauncherActivity.packageSupportsSiteSettings(action.provider, mPackageManager));
+        assertFalse(ManageDataLauncherActivity
+                .packageSupportsSiteSettings(action.provider, mPackageManager));
     }
 
     @Test
@@ -110,21 +114,23 @@ public class ManageDataLauncherActivityTest {
     public void returnsSiteSettingsShortcut() {
         installTrustedWebActivityProviderWithManageDataAction(TWA_PROVIDER_PACKAGE);
 
-        assertNotNull(ManageDataLauncherActivity.getSiteSettingsShortcutOrNull(mContext, mPackageManager));
+        assertNotNull(ManageDataLauncherActivity
+                .getSiteSettingsShortcutOrNull(mContext, mPackageManager));
     }
 
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
     public void returnsNullSiteSettingsShortcutWithLowSDK() {
         installTrustedWebActivityProviderWithManageDataAction(TWA_PROVIDER_PACKAGE);
-
-        assertNull(ManageDataLauncherActivity.getSiteSettingsShortcutOrNull(mContext, mPackageManager));
+        assertNull(ManageDataLauncherActivity
+                .getSiteSettingsShortcutOrNull(mContext, mPackageManager));
     }
 
     @Test
     @Config(sdk = Build.VERSION_CODES.N_MR1)
     public void returnsNullSiteSettingsShortcutWhenMissingManageDataLauncherActivity() {
-        assertNull(ManageDataLauncherActivity.getSiteSettingsShortcutOrNull(mContext, mPackageManager));
+        assertNull(ManageDataLauncherActivity
+                .getSiteSettingsShortcutOrNull(mContext, mPackageManager));
     }
 
     private void installBrowser(String packageName) {


### PR DESCRIPTION
The commit adds a dynamic shortcut that links to the TWA's site settings provided that the following conditions are met:
    1. The manifest of the TWA declared ManageDataLauncherActivity - needed to launch site settings
    2. The TWA provider supports site settings either via a custom manifest category, or if it is a legacy version of chrome 