### PR TITLE
Bumped version to 2.0.0

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
-def VERSION = "1.3.2";
+def VERSION = "2.0.0";
 
 android {
     compileSdkVersion 30


### PR DESCRIPTION
- The dependency on androix.appcompat was removed, which allows
  outputting smaller APKs when using the library.
- But this means existing applications may need to update
  `styles.xml` to remove the dependency and extend Activity
  instead of AppCompatActivity.