### PR TITLE
Implement DigitalGoods Acknowledge call

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/AcknowledgeCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/AcknowledgeCall.java
@@ -25,7 +25,7 @@ import androidx.annotation.Nullable;
 
 /**
  * A class for parsing Digital Goods API calls from the browser and converting them into a format
- * suitable for calling the Play Biling library.
+ * suitable for calling the Play Billing library.
  */
 public class AcknowledgeCall {
     private static final String TAG = "TwaBilling";

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
@@ -77,6 +77,11 @@ public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
                 if (getDetailsCall == null) break;
                 getDetailsCall.call(mWrapper);
                 return true;
+            case AcknowledgeCall.COMMAND_NAME:
+                AcknowledgeCall acknowledgeCall = AcknowledgeCall.create(args, callback);
+                if (acknowledgeCall == null) break;
+                acknowledgeCall.call(mWrapper);
+                return true;
         }
         return false;
     }

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/GetDetailsCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/GetDetailsCall.java
@@ -16,8 +16,10 @@ package com.google.androidbrowserhelper.playbilling.digitalgoods;
 
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.util.Log;
 
 import com.android.billingclient.api.AcknowledgePurchaseParams;
+import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.SkuDetails;
 import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
@@ -32,6 +34,8 @@ import androidx.annotation.Nullable;
  * suitable for calling the Play Biling library.
  */
 public class GetDetailsCall {
+    private static final String TAG = "TwaBilling";
+
     public static final String COMMAND_NAME = "getDetails";
 
     static final String PARAM_GET_DETAILS_ITEM_IDS = "getDetails.itemIds";
@@ -60,7 +64,13 @@ public class GetDetailsCall {
     }
 
     /** Calls the callback provided in the constructor with serialized forms of the parameters. */
-    private void respond(BillingResult code, List<SkuDetails> detailsList) {
+    private void respond(BillingResult result, List<SkuDetails> detailsList) {
+        int responseCode = result.getResponseCode();
+        if (responseCode != BillingClient.BillingResponseCode.OK) {
+            Log.w(TAG, "Billing returned non-OK response code: " + responseCode + ", "
+                    + result.getDebugMessage());
+        }
+
         Parcelable[] parcelables = new Parcelable[detailsList.size()];
 
         int index = 0;
@@ -69,7 +79,7 @@ public class GetDetailsCall {
         }
 
         Bundle args = new Bundle();
-        args.putInt(RESPONSE_GET_DETAILS_RESPONSE_CODE, code.getResponseCode());
+        args.putInt(RESPONSE_GET_DETAILS_RESPONSE_CODE, responseCode);
         args.putParcelableArray(RESPONSE_GET_DETAILS_DETAILS_LIST, parcelables);
         mCallback.run(RESPONSE_GET_DETAILS, args);
     }

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
@@ -16,6 +16,8 @@ package com.google.androidbrowserhelper.playbilling.provider;
 
 import android.app.Activity;
 
+import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
+import com.android.billingclient.api.ConsumeResponseListener;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsResponseListener;
 
@@ -47,6 +49,16 @@ public interface BillingWrapper {
      * Get {@link SkuDetails} objects for the provided SKUs.
      */
     void querySkuDetails(List<String> skus, SkuDetailsResponseListener callback);
+
+    /**
+     * Acknowledges that a purchase has occured.
+     */
+    void acknowledge(String token, AcknowledgePurchaseResponseListener callback);
+
+    /**
+     * Consumes a repeatable purchase.
+     */
+    void consume(String token, ConsumeResponseListener callback);
 
     /**
      * Launches the Payment Flow. If it returns {@code true},

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
@@ -36,6 +36,10 @@ public class MockBillingWrapper implements BillingWrapper {
     private List<String> mQueriedSkuDetails;
     private boolean mPaymentFlowSuccessful;
     private SkuDetailsResponseListener mPendingQuerySkuDetailsCallback;
+    private String mAcknowledgeToken;
+    private AcknowledgePurchaseResponseListener mPendingAcknowledgeCallback;
+    private String mConsumeToken;
+    private ConsumeResponseListener mPendingConsumeCallback;
 
     private final CountDownLatch mConnectLatch = new CountDownLatch(1);
     private final CountDownLatch mQuerySkuDetailsLatch = new CountDownLatch(1);
@@ -55,12 +59,14 @@ public class MockBillingWrapper implements BillingWrapper {
 
     @Override
     public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
-
+        mAcknowledgeToken = token;
+        mPendingAcknowledgeCallback = callback;
     }
 
     @Override
     public void consume(String token, ConsumeResponseListener callback) {
-
+        mConsumeToken = token;
+        mPendingConsumeCallback = callback;
     }
 
     @Override
@@ -84,6 +90,16 @@ public class MockBillingWrapper implements BillingWrapper {
     public void triggerOnGotSkuDetails(int responseCode, List<SkuDetails> skuDetails) {
         BillingResult result = BillingResult.newBuilder().setResponseCode(responseCode).build();
         mPendingQuerySkuDetailsCallback.onSkuDetailsResponse(result, skuDetails);
+    }
+
+    public void triggerAcknowledge(int responseCode) {
+        BillingResult result = BillingResult.newBuilder().setResponseCode(responseCode).build();
+        mPendingAcknowledgeCallback.onAcknowledgePurchaseResponse(result);
+    }
+
+    public void triggerConsume(int responseCode, String token) {
+        BillingResult result = BillingResult.newBuilder().setResponseCode(responseCode).build();
+        mPendingConsumeCallback.onConsumeResponse(result, token);
     }
 
     public void triggerOnPurchasesUpdated() {
@@ -112,6 +128,14 @@ public class MockBillingWrapper implements BillingWrapper {
 
     public List<String> getQueriedSkuDetails() {
         return mQueriedSkuDetails;
+    }
+
+    public String getConsumeToken() {
+        return mConsumeToken;
+    }
+
+    public String getAcknowledgeToken() {
+        return mAcknowledgeToken;
     }
 
     private static boolean wait(CountDownLatch latch) throws InterruptedException {

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
@@ -16,8 +16,10 @@ package com.google.androidbrowserhelper.playbilling.provider;
 
 import android.app.Activity;
 
+import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.ConsumeResponseListener;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsResponseListener;
 
@@ -49,6 +51,16 @@ public class MockBillingWrapper implements BillingWrapper {
         mQueriedSkuDetails = skus;
         mQuerySkuDetailsLatch.countDown();
         mPendingQuerySkuDetailsCallback = callback;
+    }
+
+    @Override
+    public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
+
+    }
+
+    @Override
+    public void consume(String token, ConsumeResponseListener callback) {
+
     }
 
     @Override

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -17,10 +17,14 @@ package com.google.androidbrowserhelper.playbilling.provider;
 import android.app.Activity;
 import android.content.Context;
 
+import com.android.billingclient.api.AcknowledgePurchaseParams;
+import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.ConsumeParams;
+import com.android.billingclient.api.ConsumeResponseListener;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchasesUpdatedListener;
 import com.android.billingclient.api.SkuDetails;
@@ -79,6 +83,26 @@ public class PlayBillingWrapper implements BillingWrapper {
                 .build();
 
         mClient.querySkuDetailsAsync(params, callback);
+    }
+
+    @Override
+    public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
+        AcknowledgePurchaseParams params = AcknowledgePurchaseParams
+                .newBuilder()
+                .setPurchaseToken(token)
+                .build();
+
+        mClient.acknowledgePurchase(params, callback);
+    }
+
+    @Override
+    public void consume(String token, ConsumeResponseListener callback) {
+        ConsumeParams params = ConsumeParams
+                .newBuilder()
+                .setPurchaseToken(token)
+                .build();
+
+        mClient.consumeAsync(params, callback);
     }
 
     @Override

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
@@ -128,8 +128,16 @@ public class DigitalGoodsTests {
     }
 
     @Test
-    public void acknowledgeCall_callsAcknowledge() {
-        boolean makeAvailableAgain = true;
+    public void acknowledgeCall_callsAcknowledge() throws InterruptedException {
+        callAcknowledge(true);
+    }
+
+    @Test
+    public void acknowledgeCall_callsConsume() throws InterruptedException {
+        callAcknowledge(false);
+    }
+
+    private void callAcknowledge(boolean makeAvailableAgain) throws InterruptedException {
         Bundle args = AcknowledgeCall.createBundleForTesting("id1", makeAvailableAgain);
         CountDownLatch callbackTriggered = new CountDownLatch(1);
 
@@ -140,11 +148,14 @@ public class DigitalGoodsTests {
 
         assertTrue(mHandler.handle(AcknowledgeCall.COMMAND_NAME, args, callback));
 
-        // TODO check things work...
-    }
+        if (makeAvailableAgain) {
+            assertEquals("id1", mBillingWrapper.getAcknowledgeToken());
+            mBillingWrapper.triggerAcknowledge(0);
+        } else {
+            assertEquals("id1", mBillingWrapper.getConsumeToken());
+            mBillingWrapper.triggerConsume(0, "?");
+        }
 
-    @Test
-    public void acknowledgeCall_callsConsume() {
-
+        assertTrue(callbackTriggered.await(5, TimeUnit.SECONDS));
     }
 }

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.AcknowledgeCall.RESPONSE_ACKNOWLEDGE;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.AcknowledgeCall.RESPONSE_ACKNOWLEDGE_RESPONSE_CODE;
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.GetDetailsCall.RESPONSE_GET_DETAILS;
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.GetDetailsCall.RESPONSE_GET_DETAILS_DETAILS_LIST;
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.GetDetailsCall.RESPONSE_GET_DETAILS_RESPONSE_CODE;
@@ -140,9 +141,11 @@ public class DigitalGoodsTests {
     private void callAcknowledge(boolean makeAvailableAgain) throws InterruptedException {
         Bundle args = AcknowledgeCall.createBundleForTesting("id1", makeAvailableAgain);
         CountDownLatch callbackTriggered = new CountDownLatch(1);
+        int expectedResponseCode = 23;
 
         DigitalGoodsCallback callback = (name, bundle) -> {
             assertEquals(RESPONSE_ACKNOWLEDGE, name);
+            assertEquals(expectedResponseCode, bundle.getInt(RESPONSE_ACKNOWLEDGE_RESPONSE_CODE));
             callbackTriggered.countDown();
         };
 
@@ -150,10 +153,10 @@ public class DigitalGoodsTests {
 
         if (makeAvailableAgain) {
             assertEquals("id1", mBillingWrapper.getAcknowledgeToken());
-            mBillingWrapper.triggerAcknowledge(0);
+            mBillingWrapper.triggerAcknowledge(expectedResponseCode);
         } else {
             assertEquals("id1", mBillingWrapper.getConsumeToken());
-            mBillingWrapper.triggerConsume(0, "?");
+            mBillingWrapper.triggerConsume(expectedResponseCode, "?");
         }
 
         assertTrue(callbackTriggered.await(5, TimeUnit.SECONDS));

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.AcknowledgeCall.RESPONSE_ACKNOWLEDGE;
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.GetDetailsCall.RESPONSE_GET_DETAILS;
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.GetDetailsCall.RESPONSE_GET_DETAILS_DETAILS_LIST;
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.GetDetailsCall.RESPONSE_GET_DETAILS_RESPONSE_CODE;
@@ -124,5 +125,26 @@ public class DigitalGoodsTests {
         mBillingWrapper.triggerOnGotSkuDetails(Collections.singletonList(new SkuDetails(skuJson)));
 
         assertTrue(callbackTriggered.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void acknowledgeCall_callsAcknowledge() {
+        boolean makeAvailableAgain = true;
+        Bundle args = AcknowledgeCall.createBundleForTesting("id1", makeAvailableAgain);
+        CountDownLatch callbackTriggered = new CountDownLatch(1);
+
+        DigitalGoodsCallback callback = (name, bundle) -> {
+            assertEquals(RESPONSE_ACKNOWLEDGE, name);
+            callbackTriggered.countDown();
+        };
+
+        assertTrue(mHandler.handle(AcknowledgeCall.COMMAND_NAME, args, callback));
+
+        // TODO check things work...
+    }
+
+    @Test
+    public void acknowledgeCall_callsConsume() {
+
     }
 }


### PR DESCRIPTION
The Acknowledge call allows the TWA's website to trigger either the Play Billing acknowledge or consumeAsync methods. This is the last big part of DigitalGoodsRequestHandler to be implemented (although that class has some further cleanup still needed).