### PR TITLE
Make BillingWrapper#connect take callbacks.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
@@ -31,19 +31,8 @@ import androidx.browser.trusted.TrustedWebActivityCallbackRemote;
 
 public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
     private final BillingWrapper mWrapper;
-    private final BillingWrapper.Listener mListener = new BillingWrapper.Listener() {
-        @Override
-        public void onConnected() {
-            // TODO: Sort out connection lifecycle.
-        }
-
-        @Override
-        public void onDisconnected() {
-            // TODO: Sort out connection lifecycle.
-        }
-
-        @Override
-        public void onPurchaseFlowComplete(int result) { }
+    private final BillingWrapper.Listener mListener = result -> {
+        throw new IllegalStateException("DigitalGoods does not support Payment Flows.");
     };
 
     public DigitalGoodsRequestHandler(Context context) {

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
@@ -17,6 +17,7 @@ package com.google.androidbrowserhelper.playbilling.provider;
 import android.app.Activity;
 
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
+import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.ConsumeResponseListener;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsResponseListener;
@@ -32,18 +33,12 @@ public interface BillingWrapper {
      * Callbacks for connection state and for purchase flow completion.
      */
     interface Listener {
-        /** Will be called when connected to the Play Billing client. */
-        void onConnected();
-
-        /** Will be called when the Play Billing client disconnects. */
-        void onDisconnected();
-
         /** Will be called after a call to {@link #launchPaymentFlow} that returns {@code true}. */
         void onPurchaseFlowComplete(int result);
     }
 
     /** Connect to the Play Billing client. */
-    void connect();
+    void connect(BillingClientStateListener callback);
 
     /**
      * Get {@link SkuDetails} objects for the provided SKUs.

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentActivity.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentActivity.java
@@ -19,6 +19,7 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import com.android.billingclient.api.BillingClient;
+import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.SkuDetails;
 
@@ -58,15 +59,23 @@ public class PaymentActivity extends AppCompatActivity implements BillingWrapper
         }
 
         mWrapper = BillingWrapperFactory.get(this, this);
-        mWrapper.connect();
+        mWrapper.connect(new BillingClientStateListener() {
+            @Override
+            public void onBillingSetupFinished(BillingResult billingResult) {
+                onConnected();
+            }
+
+            @Override
+            public void onBillingServiceDisconnected() {
+                onDisconnected();
+            }
+        });
     }
 
-    @Override
     public void onDisconnected() {
         fail("BillingClient disconnected.");
     }
 
-    @Override
     public void onConnected() {
         mWrapper.querySkuDetails(Collections.singletonList(mMethodData.sku),
                 (BillingResult result, List<SkuDetails> details) -> {

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -60,18 +60,8 @@ public class PlayBillingWrapper implements BillingWrapper {
     }
 
     @Override
-    public void connect() {
-        mClient.startConnection(new BillingClientStateListener() {
-            @Override
-            public void onBillingSetupFinished(BillingResult billingResult) {
-                mListener.onConnected();
-            }
-
-            @Override
-            public void onBillingServiceDisconnected() {
-                mListener.onDisconnected();
-            }
-        });
+    public void connect(BillingClientStateListener callback) {
+        mClient.startConnection(callback);
     }
 
     @Override


### PR DESCRIPTION
This PR changes how clients of BillingWrapper are notified of connection state changes.

It lays the groundwork for a future PR that automatically connects BillingWrapper.