### PR TITLE
Create a BillingWrapper that ensures we are connected.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.androidbrowserhelper.playbilling.digitalgoods;
 
 import android.app.Activity;
@@ -25,17 +39,13 @@ public class ConnectedBillingWrapper implements BillingWrapper {
     private static final int CONNECTED = 2;
     private int mState = NOT_CONNECTED;
 
-    private interface Callback {
-        void run();
-    }
-
-    private final List<Callback> mPendingCallbacks = new ArrayList<>();
+    private final List<Runnable> mPendingCallbacks = new ArrayList<>();
 
     public ConnectedBillingWrapper(BillingWrapper mInner) {
         this.mInner = mInner;
     }
 
-    private void execute(Callback callback) {
+    private void execute(Runnable callback) {
         if (mState == CONNECTED) {
             callback.run();
             return;
@@ -51,7 +61,7 @@ public class ConnectedBillingWrapper implements BillingWrapper {
             public void onBillingSetupFinished(BillingResult billingResult) {
                 mState = CONNECTED;
 
-                for (Callback callback : mPendingCallbacks) {
+                for (Runnable callback : mPendingCallbacks) {
                     callback.run();
                 }
 

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
@@ -1,0 +1,93 @@
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import android.app.Activity;
+
+import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
+import com.android.billingclient.api.BillingClientStateListener;
+import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.ConsumeResponseListener;
+import com.android.billingclient.api.SkuDetails;
+import com.android.billingclient.api.SkuDetailsResponseListener;
+import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A wrapper around {@link BillingWrapper} that ensures it is connected before calling
+ * {@link #querySkuDetails}, {@link #acknowledge} or {@link #consume}.
+ */
+public class ConnectedBillingWrapper implements BillingWrapper {
+    private final BillingWrapper mInner;
+
+    private static final int NOT_CONNECTED = 0;
+    private static final int CONNECTING = 1;
+    private static final int CONNECTED = 2;
+    private int mState = NOT_CONNECTED;
+
+    private interface Callback {
+        void run();
+    }
+
+    private final List<Callback> mPendingCallbacks = new ArrayList<>();
+
+    public ConnectedBillingWrapper(BillingWrapper mInner) {
+        this.mInner = mInner;
+    }
+
+    private void execute(Callback callback) {
+        if (mState == CONNECTED) {
+            callback.run();
+            return;
+        }
+
+        mPendingCallbacks.add(callback);
+
+        if (mState == CONNECTING) return;
+
+        mState = CONNECTING;
+        mInner.connect(new BillingClientStateListener() {
+            @Override
+            public void onBillingSetupFinished(BillingResult billingResult) {
+                mState = CONNECTED;
+
+                for (Callback callback : mPendingCallbacks) {
+                    callback.run();
+                }
+
+                mPendingCallbacks.clear();
+            }
+
+            @Override
+            public void onBillingServiceDisconnected() {
+                mState = NOT_CONNECTED;
+            }
+        });
+    }
+
+    @Override
+    public void connect(BillingClientStateListener callback) {
+        execute(() -> {});
+    }
+
+    @Override
+    public void querySkuDetails(List<String> skus, SkuDetailsResponseListener callback) {
+        execute(() -> mInner.querySkuDetails(skus, callback));
+    }
+
+    @Override
+    public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
+        execute(() -> mInner.acknowledge(token, callback));
+    }
+
+    @Override
+    public void consume(String token, ConsumeResponseListener callback) {
+        execute(() -> mInner.consume(token, callback));
+    }
+
+    @Override
+    public boolean launchPaymentFlow(Activity activity, SkuDetails sku) {
+        throw new IllegalStateException(
+                "EnsuredConnectionBillingWrapper doesn't handle launch Payment flow");
+    }
+}

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
@@ -36,7 +36,7 @@ public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
     };
 
     public DigitalGoodsRequestHandler(Context context) {
-        mWrapper = BillingWrapperFactory.get(context, mListener);
+        mWrapper = new ConnectedBillingWrapper(BillingWrapperFactory.get(context, mListener));
     }
 
     @NonNull

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapperTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapperTest.java
@@ -1,0 +1,111 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
+import com.google.androidbrowserhelper.playbilling.provider.MockBillingWrapper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.internal.DoNotInstrument;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(RobolectricTestRunner.class)
+@DoNotInstrument
+@Config(manifest = Config.NONE)
+public class ConnectedBillingWrapperTest {
+    private final MockBillingWrapper mInnerBillingWrapper = new MockBillingWrapper();
+    private final BillingWrapper mConnectedWrapper =
+            new ConnectedBillingWrapper(mInnerBillingWrapper);
+
+    @Test
+    public void delays_getDetailsCall() {
+        mConnectedWrapper.querySkuDetails(Collections.singletonList("id1"), null);
+        assertNull(mInnerBillingWrapper.getQueriedSkuDetails());
+
+        mInnerBillingWrapper.triggerConnected();
+        assertEquals(mInnerBillingWrapper.getQueriedSkuDetails().get(0), "id1");
+    }
+
+    @Test
+    public void delays_acknowledgeCall() {
+        mConnectedWrapper.acknowledge("id1", null);
+        assertNull(mInnerBillingWrapper.getAcknowledgeToken());
+
+        mInnerBillingWrapper.triggerConnected();
+        assertEquals(mInnerBillingWrapper.getAcknowledgeToken(), "id1");
+    }
+
+    @Test
+    public void delays_consumeCall() {
+        mConnectedWrapper.consume("id1", null);
+        assertNull(mInnerBillingWrapper.getConsumeToken());
+
+        mInnerBillingWrapper.triggerConnected();
+        assertEquals(mInnerBillingWrapper.getConsumeToken(), "id1");
+    }
+
+    @Test
+    public void forwards_getDetailsCall() {
+        mConnectedWrapper.connect(null);
+        mInnerBillingWrapper.triggerConnected();
+
+        mConnectedWrapper.querySkuDetails(Collections.singletonList("id1"), null);
+        assertEquals(mInnerBillingWrapper.getQueriedSkuDetails().get(0), "id1");
+    }
+
+    @Test
+    public void forwards_acknowledge() {
+        mConnectedWrapper.connect(null);
+        mInnerBillingWrapper.triggerConnected();
+
+        mConnectedWrapper.acknowledge("id1", null);
+        assertEquals(mInnerBillingWrapper.getAcknowledgeToken(), "id1");
+    }
+
+    @Test
+    public void forwards_consume() {
+        mConnectedWrapper.connect(null);
+        mInnerBillingWrapper.triggerConnected();
+
+        mConnectedWrapper.consume("id1", null);
+        assertEquals(mInnerBillingWrapper.getConsumeToken(), "id1");
+    }
+
+    @Test
+    public void reconnects() {
+        mConnectedWrapper.connect(null);
+        mInnerBillingWrapper.triggerConnected();
+
+        mConnectedWrapper.consume("id1", null);
+        assertEquals(mInnerBillingWrapper.getConsumeToken(), "id1");
+
+        mInnerBillingWrapper.triggerDisconnected();
+
+        mConnectedWrapper.consume("id2", null);
+        // The most recent call won't have got through yet, so we're still checking for the previous
+        // id.
+        assertEquals(mInnerBillingWrapper.getConsumeToken(), "id1");
+
+        mInnerBillingWrapper.triggerConnected();
+        assertEquals(mInnerBillingWrapper.getConsumeToken(), "id2");
+    }
+}

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
@@ -83,6 +83,7 @@ public class DigitalGoodsTests {
         DigitalGoodsCallback callback = (name, bundle) -> callbackTriggered.countDown();
 
         assertTrue(mHandler.handle( GetDetailsCall.COMMAND_NAME, args, callback));
+        mBillingWrapper.triggerConnected();
 
         assertTrue(mBillingWrapper.waitForQuerySkuDetails());
         mBillingWrapper.triggerOnGotSkuDetails(Collections.emptyList());
@@ -121,6 +122,7 @@ public class DigitalGoodsTests {
         };
 
         assertTrue(mHandler.handle(GetDetailsCall.COMMAND_NAME, args, callback));
+        mBillingWrapper.triggerConnected();
 
         assertTrue(mBillingWrapper.waitForQuerySkuDetails());
         mBillingWrapper.triggerOnGotSkuDetails(Collections.singletonList(new SkuDetails(skuJson)));
@@ -150,6 +152,7 @@ public class DigitalGoodsTests {
         };
 
         assertTrue(mHandler.handle(AcknowledgeCall.COMMAND_NAME, args, callback));
+        mBillingWrapper.triggerConnected();
 
         if (makeAvailableAgain) {
             assertEquals("id1", mBillingWrapper.getAcknowledgeToken());


### PR DESCRIPTION
This PR adds the `ConnectedBillingWrapper` that takes a `BillingWrapper` and ensures that connect is called (and completes) before calling any of its methods.