### PR TITLE
Add Digital Goods Service and Payment Activity to demo.

### DIFF
--- a/demos/payment-provider/build.gradle
+++ b/demos/payment-provider/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.google.androidbrowserhelper.paymentprovider"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/demos/payment-provider/src/main/AndroidManifest.xml
+++ b/demos/payment-provider/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
         <activity
             android:name="com.google.androidbrowserhelper.playbilling.provider.PaymentActivity"
             android:exported="true"
-            android:theme="@style/Theme.Transparent">
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
 
             <intent-filter>
                 <action android:name="org.chromium.intent.action.PAY" />

--- a/demos/payment-provider/src/main/res/values/styles.xml
+++ b/demos/payment-provider/src/main/res/values/styles.xml
@@ -1,20 +1,25 @@
+<!--
+    Copyright 2020 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <resources>
-
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.DarkActionBar">
         <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-    </style>
-
-    <style name="Theme.Transparent" parent="Theme.AppCompat">
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowIsFloating">true</item>
-        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:colorPrimary">@color/colorPrimary</item>
+        <item name="android:colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="android:colorAccent">@color/colorAccent</item>
     </style>
 
 </resources>

--- a/demos/twa-play-billing/src/main/AndroidManifest.xml
+++ b/demos/twa-play-billing/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
             android:resource="@string/asset_statements" />
 
         <activity android:name="com.google.androidbrowserhelper.trusted.LauncherActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
             <meta-data android:name="android.support.customtabs.trusted.DEFAULT_URL"
                 android:value="https://beer.conn.dev" />
 
@@ -54,12 +55,35 @@
         <activity android:name="com.google.androidbrowserhelper.trusted.FocusActivity" />
 
         <service
-            android:name="com.google.androidbrowserhelper.trusted.DelegationService"
+            android:name=".ExtraFeaturesService"
             android:exported="true">
 
             <intent-filter>
                 <action android:name="android.support.customtabs.trusted.TRUSTED_WEB_ACTIVITY_SERVICE"/>
                 <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </service>
+
+        <activity
+            android:name="com.google.androidbrowserhelper.playbilling.provider.PaymentActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="org.chromium.intent.action.PAY" />
+            </intent-filter>
+
+            <meta-data
+                android:name="org.chromium.default_payment_method_name"
+                android:value="https://play.google.com/billing" />
+        </activity>
+
+        <!-- This service checks who calls it at runtime. -->
+        <service
+            android:name="com.google.androidbrowserhelper.playbilling.provider.PaymentService"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="org.chromium.intent.action.IS_READY_TO_PAY" />
             </intent-filter>
         </service>
 

--- a/demos/twa-play-billing/src/main/java/com/google/androidbrowserhelper/demos/playbilling/ExtraFeaturesService.java
+++ b/demos/twa-play-billing/src/main/java/com/google/androidbrowserhelper/demos/playbilling/ExtraFeaturesService.java
@@ -1,0 +1,13 @@
+package com.google.androidbrowserhelper.demos.playbilling;
+
+import com.google.androidbrowserhelper.playbilling.digitalgoods.DigitalGoodsRequestHandler;
+import com.google.androidbrowserhelper.trusted.DelegationService;
+
+public class ExtraFeaturesService extends DelegationService {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        registerExtraCommandHandler(new DigitalGoodsRequestHandler(getApplicationContext()));
+    }
+}

--- a/playbilling/build.gradle
+++ b/playbilling/build.gradle
@@ -35,7 +35,6 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'com.android.billingclient:billing:2.1.0'
 

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentActivity.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentActivity.java
@@ -14,6 +14,7 @@
 
 package com.google.androidbrowserhelper.playbilling.provider;
 
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Bundle;
@@ -27,9 +28,8 @@ import java.util.Collections;
 import java.util.List;
 
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 
-public class PaymentActivity extends AppCompatActivity implements BillingWrapper.Listener {
+public class PaymentActivity extends Activity implements BillingWrapper.Listener {
     private static final String TAG = "PaymentActivity";
 
     private static final String METHOD_NAME = "https://beer.conn.dev";


### PR DESCRIPTION
This change should make the `twa-play-billing` demo fully functional (provided you've got the Digital Asset Link verification set up).

It:
* Adds a `ExtraFeaturesService` that uses the `DigitalGoodsRequestHandler`.
* Adds the Payment Provider to the demo's manifest.
* Makes the Payment Provider extend `Activity` instead of `AppCompatActivity`.