### PR TITLE
Add support for overriding site settings icon

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
@@ -86,6 +86,9 @@ public class ManageDataLauncherActivity extends Activity {
     public static final String CATEGORY_LAUNCH_SITE_SETTINGS =
             "androidx.browser.trusted.category.LaunchSiteSettings";
 
+    public static final String OVERRIDE_IC_SITE_SETTINGS_ID =
+            "drawable/override_ic_site_settings";
+
     @Nullable
     private String mProviderPackage;
 
@@ -350,11 +353,13 @@ public class ManageDataLauncherActivity extends Activity {
 
         if(activities.size() == 0) return null;
 
+        int shortcutIconId = context.getResources().getIdentifier(
+                OVERRIDE_IC_SITE_SETTINGS_ID, "drawable", context.getPackageName());
         return new ShortcutInfo.Builder(context, SITE_SETTINGS_SHORTCUT_ID)
                 .setShortLabel("Site Settings")
                 .setLongLabel("Manage website notifications, permissions, etc.")
                 .setIcon(Icon.createWithResource(context,
-                        R.drawable.ic_site_settings))
+                        shortcutIconId != 0 ? shortcutIconId : R.drawable.ic_site_settings))
                 .setIntent(siteSettingsIntent)
                 .build();
     }


### PR DESCRIPTION
Responding to this issue https://github.com/GoogleChrome/android-browser-helper/issues/181, we are adding support for overriding the site settings icon.

When adding the shortcut, we check whether override_ic_site_settings is present as a drawable and use it. Otherwise, we fall back to the default ic_site_settings icon.