### PR TITLE
Pass purchase token to browser.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
@@ -18,12 +18,9 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.RemoteException;
 
-import com.android.billingclient.api.SkuDetails;
 import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
 import com.google.androidbrowserhelper.playbilling.provider.BillingWrapperFactory;
 import com.google.androidbrowserhelper.trusted.ExtraCommandHandler;
-
-import java.util.Arrays;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -31,7 +28,7 @@ import androidx.browser.trusted.TrustedWebActivityCallbackRemote;
 
 public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
     private final BillingWrapper mWrapper;
-    private final BillingWrapper.Listener mListener = result -> { };
+    private final BillingWrapper.Listener mListener = (result, token) -> { };
 
     public DigitalGoodsRequestHandler(Context context) {
         mWrapper = new ConnectedBillingWrapper(BillingWrapperFactory.get(context, mListener));
@@ -58,8 +55,6 @@ public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
 
     public boolean handle(@NonNull String commandName, @NonNull Bundle args,
             @Nullable DigitalGoodsCallback callback) {
-        Logging.logCommand(commandName);
-
         switch (commandName) {
             case GetDetailsCall.COMMAND_NAME:
                 GetDetailsCall getDetailsCall = GetDetailsCall.create(args, callback);
@@ -72,6 +67,8 @@ public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
                 acknowledgeCall.call(mWrapper);
                 return true;
         }
+
+        Logging.logUnknownCommand(commandName);
         return false;
     }
 }

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/Logging.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/Logging.java
@@ -27,8 +27,8 @@ import java.util.List;
 public class Logging {
     private static final String TAG = "TwaBilling.DG";
 
-    static void logCommand(String commandName) {
-        Log.d(TAG, "Got command: " + commandName);
+    static void logUnknownCommand(String commandName) {
+        Log.d(TAG, "Got unknown command: " + commandName);
     }
 
     static void logAckCall(String token, boolean makeAvailableAgain) {
@@ -41,11 +41,7 @@ public class Logging {
 
     static void logAckResponse(BillingResult result, boolean makeAvailableAgain) {
         String command = makeAvailableAgain ? "Acknowledge" : "Consume";
-        int responseCode = result.getResponseCode();
-        Log.d(TAG, command + " returned code " + responseCode);
-        if (responseCode != BillingClient.BillingResponseCode.OK) {
-            Log.d(TAG, result.getDebugMessage());
-        }
+        logResult(result, command + " returned:");
     }
 
     static void logGetDetailsCall(List<String> ids) {
@@ -63,10 +59,16 @@ public class Logging {
     }
 
     static void logGetDetailsResponse(BillingResult result) {
+        logResult(result, "GetDetails returned:");
+    }
+
+    private static void logResult(BillingResult result, String message) {
         int responseCode = result.getResponseCode();
-        Log.d(TAG, "GetDetails returned code " + responseCode);
-        if (responseCode != BillingClient.BillingResponseCode.OK) {
-            Log.d(TAG, result.getDebugMessage());
+
+        Log.d(TAG, message + " " + responseCode);
+        String debugMessage = result.getDebugMessage();
+        if (debugMessage != null && !debugMessage.isEmpty()) {
+            Log.d(TAG, debugMessage);
         }
     }
 

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
@@ -35,7 +35,7 @@ public interface BillingWrapper {
      */
     interface Listener {
         /** Will be called after a call to {@link #launchPaymentFlow} that returns {@code true}. */
-        void onPurchaseFlowComplete(BillingResult result);
+        void onPurchaseFlowComplete(BillingResult result, String purchaseToken);
     }
 
     /** Connect to the Play Billing client. */

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/Logging.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/Logging.java
@@ -18,6 +18,11 @@ import android.util.Log;
 
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.Purchase;
+
+import java.util.List;
+
+import androidx.annotation.Nullable;
 
 /**
  * Consolidates all the logging for this package in one place.
@@ -26,24 +31,26 @@ public class Logging {
     private static final String TAG = "TwaBilling.P";
 
     static void logLaunchPaymentFlow(BillingResult result) {
-        int responseCode = result.getResponseCode();
+        logResult(result, "Payment flow launch:");
+    }
 
-        if (responseCode != BillingClient.BillingResponseCode.OK) {
-            Log.d(TAG, "Payment flow failed to launch " + responseCode);
-            Log.d(TAG, result.getDebugMessage());
+    static void logPurchasesUpdate(BillingResult result, @Nullable List<Purchase> list) {
+        logResult(result, "Purchases updated:");
+
+        if (list == null) {
+            Log.d(TAG, "No items updated.");
         } else {
-            Log.d(TAG, "Payment Flow launched " + responseCode);
+            Log.d(TAG, list.size() + " item(s) updated.");
         }
     }
 
-    static void logPaymentFlowComplete(BillingResult result) {
+    private static void logResult(BillingResult result, String message) {
         int responseCode = result.getResponseCode();
 
-        if (responseCode != BillingClient.BillingResponseCode.OK) {
-            Log.d(TAG, "Payment flow failed " + responseCode);
-            Log.d(TAG, result.getDebugMessage());
-        } else {
-            Log.d(TAG, "Payment Flow succeeded " + responseCode);
+        Log.d(TAG, message + " " + responseCode);
+        String debugMessage = result.getDebugMessage();
+        if (debugMessage != null && !debugMessage.isEmpty()) {
+            Log.d(TAG, debugMessage);
         }
     }
 }

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
@@ -111,7 +111,7 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     public void triggerOnPurchasesUpdated() {
-        mListener.onPurchaseFlowComplete(toResult(BillingClient.BillingResponseCode.OK));
+        mListener.onPurchaseFlowComplete(toResult(BillingClient.BillingResponseCode.OK), "");
     }
 
     public boolean waitForConnect() throws InterruptedException {

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentActivity.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentActivity.java
@@ -95,11 +95,9 @@ public class PaymentActivity extends Activity implements BillingWrapper.Listener
     }
 
     @Override
-    public void onPurchaseFlowComplete(BillingResult result) {
-        Logging.logPaymentFlowComplete(result);
-
+    public void onPurchaseFlowComplete(BillingResult result, String purchaseToken) {
         if (result.getResponseCode() == BillingClient.BillingResponseCode.OK) {
-            setResultAndFinish(PaymentResult.success("success"));
+            setResultAndFinish(PaymentResult.success(purchaseToken));
         } else {
             fail("Purchase flow ended with result: " + result);
         }

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentResult.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentResult.java
@@ -32,8 +32,8 @@ public abstract class PaymentResult {
         return new Failure(reason);
     }
 
-    public static PaymentResult success(String id) {
-        return new Success(id);
+    public static PaymentResult success(String purchaseToken) {
+        return new Success(purchaseToken);
     }
 
     public abstract int getActivityResult();
@@ -52,10 +52,10 @@ public abstract class PaymentResult {
     protected abstract JSONObject toJson() throws JSONException;
 
     private static class Success extends PaymentResult {
-        private final String mId;
+        private final String mPurchaseToken;
 
-        private Success(String id) {
-            mId = id;
+        private Success(String purchaseToken) {
+            mPurchaseToken = purchaseToken;
         }
 
         @Override
@@ -71,7 +71,7 @@ public abstract class PaymentResult {
         @Override
         protected JSONObject toJson() throws JSONException {
             JSONObject obj = new JSONObject();
-            obj.put("id", mId);
+            obj.put("token", mPurchaseToken);
             return obj;
         }
 

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -46,7 +46,13 @@ public class PlayBillingWrapper implements BillingWrapper {
             new PurchasesUpdatedListener() {
         @Override
         public void onPurchasesUpdated(BillingResult billingResult, @Nullable List<Purchase> list) {
-            mListener.onPurchaseFlowComplete(billingResult);
+            Logging.logPurchasesUpdate(billingResult, list);
+
+            if (list == null || list.size() == 0) {
+                mListener.onPurchaseFlowComplete(billingResult, "");
+            } else {
+                mListener.onPurchaseFlowComplete(billingResult, list.get(0).getPurchaseToken());
+            }
         }
     };
 


### PR DESCRIPTION
Hey,

There are three parts to this PR:
1. Adding the purchase token given by the Play Billing flow to the Bundle returned to the browser.
2. Changing `BillingWrapper.Listener#onPurchaseFlowComplete` to take the token as a parameter so we can move it around.
3. Changing the logging added in the last PR around a bit.