### PR TITLE
Added trailing slash to WebView fallback referrer

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/WebViewFallbackActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/WebViewFallbackActivity.java
@@ -140,7 +140,7 @@ public class WebViewFallbackActivity extends Activity {
         // Applications running in a Trusted Web Activity are supposed to have
         // android-app://<package-name> as the referrer.
         Map<String, String> headers = new HashMap<>();
-        headers.put("Referer", "android-app://" + getPackageName());
+        headers.put("Referer", "android-app://" + getPackageName() + "/");
         mWebView.loadUrl(mLaunchUrl.toString(), headers);
     }
 


### PR DESCRIPTION
- Ensures compatibility with the Chrome implementation.
- Ensures it differentiates com.example from com.example.subdomain.