### PR TITLE
Fixes package for the twa-location-delegation demo

### DIFF
--- a/demos/twa-notification-delegation/build.gradle
+++ b/demos/twa-notification-delegation/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "29.0.2"
 
     defaultConfig {
-        applicationId "com.google.browser.examples.twa_notification_delegation"
+        applicationId "com.google.androidbrowserhelper.demos.twa_notification_delegation"
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 1

--- a/demos/twa-notification-delegation/src/main/AndroidManifest.xml
+++ b/demos/twa-notification-delegation/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
     limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.browser.examples.twa_notification_delegation">
+    package="com.google.androidbrowserhelper.demos.twa_notification_delegation">
 
     <application
         android:allowBackup="true"

--- a/demos/twa-notification-delegation/src/main/java/com/google/androidbrowserhelper/demos/twa_notification_delegation/NotificationDelegationService.java
+++ b/demos/twa-notification-delegation/src/main/java/com/google/androidbrowserhelper/demos/twa_notification_delegation/NotificationDelegationService.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.browser.examples.twa_notification_delegation;
+package com.google.androidbrowserhelper.demos.twa_notification_delegation;
 
 import android.app.Notification;
 import android.app.NotificationChannel;


### PR DESCRIPTION
- The directory structure didn't match the packageId, so the
  project was unable to find the NotificationDelegationService.
- Updates build.gradle, AndroidManifest and the Java file to match
  the directory structure, as we're standardising in other demos.