### PR TITLE
Report price without currency symbol.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetails.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetails.java
@@ -52,7 +52,7 @@ public class ItemDetails {
     public static ItemDetails create(SkuDetails skuDetails) {
         return new ItemDetails(skuDetails.getSku(), skuDetails.getTitle(),
                 skuDetails.getDescription(), skuDetails.getPriceCurrencyCode(),
-                skuDetails.getPrice());
+                toPrice(skuDetails.getPriceAmountMicros()));
     }
 
     /**
@@ -81,5 +81,56 @@ public class ItemDetails {
         bundle.putString(ITEM_DETAILS_VALUE, value);
 
         return bundle;
+    }
+
+    /**
+     * Takes a price amount in micro units (1,000,000 micro units = 1 unit) and converts it to a
+     * String representing the price amount in units.
+     *
+     * The reason we need this method is because {@link SkuDetails} provides either a price amount
+     * in units *with* the currency symbol, or a price amount in micro units (without the currency
+     * symbol) while we need a price without the currency symbol.
+     *
+     * We have three options:
+     * 1. Manually remove the currency symbol from the price.
+     * 2. Use numeric division to convert the price in micros to a price in units.
+     * 3. Perform string division by converting the price in micros to a string and moving the
+     *    decimal point around.
+     *
+     * Option 1 seems quite error prone and option 2 could lead to rounding errors, so we chose
+     * option 3.
+     *
+     * This may produce an ugly looking number, eg turning "£7.50" into "7.500000" but the website
+     * on the other can use Intl.NumberFormat to display the value nicely.
+     */
+    static String toPrice(long priceAmountMicros) {
+        StringBuilder sb = new StringBuilder(String.valueOf(priceAmountMicros));
+
+        // We want to perform a "string division" by inserting a decimal point 6 digits from the
+        // end. We may have to pad the string with leading zeros so that there is space to do this.
+
+        // If the number is positive, we need the string to be at least 7 characters long, so that
+        // there will be a digit to the left of the decimal point. Negative numbers need to be 8
+        // characters long to account for the minus sign.
+        int desiredLength = priceAmountMicros >= 0 ? 7 : 8;
+
+        // For positive numbers, we can insert zeros at the start, for negative numbers we must
+        // insert them after the minus sign.
+        int insertionIndex = priceAmountMicros >= 0 ? 0 : 1;
+
+        // Add leading zeros until we have the right amount of characters.
+        //      "200" ->  "0000200"
+        //     "-200" -> "-0000200"
+        // "90000000" -> "90000000"
+        while (sb.length() < desiredLength) sb.insert(insertionIndex, "0");
+
+        // Perform a "string division" by 1,000,000 by inserting a decimal point 6 characters from
+        // the end.
+        //  "0000200" ->  "0.000200"
+        // "-0000200" -> "-0.000200"
+        // "90000000" -> "90.000000"
+        sb.insert(sb.length() - 6, ".");
+
+        return sb.toString();
     }
 }

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetails.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetails.java
@@ -101,7 +101,9 @@ public class ItemDetails {
      * option 3.
      *
      * This may produce an ugly looking number, eg turning "£7.50" into "7.500000" but the website
-     * on the other can use Intl.NumberFormat to display the value nicely.
+     * receiving the value can use
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat">
+     * Intl.NumberFormat</a> to display the price nicely.
      */
     static String toPrice(long priceAmountMicros) {
         StringBuilder sb = new StringBuilder(String.valueOf(priceAmountMicros));
@@ -114,7 +116,7 @@ public class ItemDetails {
         // characters long to account for the minus sign.
         int desiredLength = priceAmountMicros >= 0 ? 7 : 8;
 
-        // For positive numbers, we can insert zeros at the start, for negative numbers we must
+        // For positive numbers we can insert zeros at the start, for negative numbers we must
         // insert them after the minus sign.
         int insertionIndex = priceAmountMicros >= 0 ? 0 : 1;
 

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
@@ -101,6 +101,7 @@ public class DigitalGoodsTests {
                 + "\"title\" = \"My item\","
                 + "\"description\" = \"Some description.\","
                 + "\"price\" = \"123.45\","
+                + "\"price_amount_micros\" = \"123450000\","
                 + "\"price_currency_code\" = \"GBP\""
                 + "}";
 
@@ -115,7 +116,7 @@ public class DigitalGoodsTests {
             assertEquals("id1", details.id);
             assertEquals("My item", details.title);
             assertEquals("Some description.", details.description);
-            assertEquals("123.45", details.value);
+            assertEquals("123.450000", details.value);
             assertEquals("GBP", details.currency);
 
             callbackTriggered.countDown();

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetailsTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetailsTest.java
@@ -1,0 +1,62 @@
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.ItemDetails.toPrice;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ItemDetails#toPrice}.
+ */
+@RunWith(Parameterized.class)
+public class ItemDetailsTest {
+    @Parameterized.Parameters(name = "toPrice({0}) = {1}")
+    public static Collection<Object[]> cases() {
+        return Arrays.asList(new Object[][] {
+                // {    input,      expected },
+                // Zero:
+                {           0L,   "0.000000" },
+                // Positive:
+                {           1L,   "0.000001" },
+                {          10L,   "0.000010" },
+                {         100L,   "0.000100" },
+                {       1_000L,   "0.001000" },
+                {      10_000L,   "0.010000" },
+                {     100_000L,   "0.100000" },
+                {   1_000_000L,   "1.000000" },
+                {  10_000_000L,  "10.000000" },
+                { 100_000_000L, "100.000000" },
+                {       1_234L,   "0.001234" },
+                { 123_456_789L, "123.456789" },
+                // Negative:
+                {           -1L,   "-0.000001" },
+                {          -10L,   "-0.000010" },
+                {         -100L,   "-0.000100" },
+                {       -1_000L,   "-0.001000" },
+                {      -10_000L,   "-0.010000" },
+                {     -100_000L,   "-0.100000" },
+                {   -1_000_000L,   "-1.000000" },
+                {  -10_000_000L,  "-10.000000" },
+                { -100_000_000L, "-100.000000" },
+                {       -1_234L,   "-0.001234" },
+                { -123_456_789L, "-123.456789" },
+        });
+    }
+    private final long mInput;
+    private final String mExpected;
+
+    public ItemDetailsTest(long input, String expected) {
+        mInput = input;
+        mExpected = expected;
+    }
+
+    @Test
+    public void test() {
+        assertEquals(mExpected, toPrice(mInput));
+    }
+}


### PR DESCRIPTION
This change reports the price of a SKU without the currency symbol.

It does make the price less pretty (for example, "7.500000" instead of "£7.50"), but the website developer can get back to the pretty version using [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) on their website.