### PR TITLE
Make PaymentActivity resistant to orientation changes.

### DIFF
--- a/demos/twa-play-billing/src/main/AndroidManifest.xml
+++ b/demos/twa-play-billing/src/main/AndroidManifest.xml
@@ -67,7 +67,7 @@
         <activity
             android:name="com.google.androidbrowserhelper.playbilling.provider.PaymentActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
-            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:configChanges="keyboardHidden|keyboard|orientation|screenLayout|screenSize"
             android:exported="true">
 
             <intent-filter>

--- a/demos/twa-play-billing/src/main/AndroidManifest.xml
+++ b/demos/twa-play-billing/src/main/AndroidManifest.xml
@@ -67,6 +67,7 @@
         <activity
             android:name="com.google.androidbrowserhelper.playbilling.provider.PaymentActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="true">
 
             <intent-filter>


### PR DESCRIPTION
This change fixes [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1129818).

When the Play Billing payment flow is launched, it forces the orientation to portrait. As it is partially transparent (and therefore the `PaymentActivity` behind is still being drawn), `PaymentActivity` also gets forced into portrait. If it was launched in landscape, this config change causes the Activity to be recreated.

Since `PaymentActivity` launches the Play Billing flow when it is created, this resulted in two different Play Billing payment flows being launched. This change makes `PaymentActivity` not get recreated on orientation change (or one or two equally likely config changes).