### PR TITLE
Allow overriding TwaLauncher creation.

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -165,7 +165,7 @@ public class LauncherActivity extends Activity {
 
         addShareDataIfPresent(twaBuilder);
 
-        mTwaLauncher = new TwaLauncher(this);
+        mTwaLauncher = createTwaLauncher();
         mTwaLauncher.launch(twaBuilder,
                 mCustomTabsCallback,
                 mSplashScreenStrategy,
@@ -182,6 +182,10 @@ public class LauncherActivity extends Activity {
 
         ManageDataLauncherActivity.addSiteSettingsShortcut(this,
                 mTwaLauncher.getProviderPackage());
+    }
+
+    protected TwaLauncher createTwaLauncher() {
+        return new TwaLauncher(this);
     }
 
     private boolean splashScreenNeeded() {


### PR DESCRIPTION
In response to [this bug](https://github.com/GoogleChromeLabs/bubblewrap/issues/353).

I'm not sure whether we want to land this because it allows locking TWAs to a specific browser. We need to give some consideration to what happens if that browser is not available.