### PR TITLE
Make GetDetails and Purchase work with subscriptions.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/BillingResultMerger.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/BillingResultMerger.java
@@ -1,0 +1,98 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import com.android.billingclient.api.BillingClient;
+import com.android.billingclient.api.BillingClient.SkuType;
+import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.SkuDetails;
+import com.android.billingclient.api.SkuDetailsResponseListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Play Billing SKUs are split into purchases and subscriptions. This isn't a distinction that
+ * exists in the Digital Goods API, but since SKU ids are unique across both product types, we can
+ * just call methods that take a skuType twice, once with {@link SkuType#INAPP} and once with
+ * {@link SkuType#SUBS}. This class exists to combine the results of those calls.
+ *
+ * Although the Play Billing methods are asynchronous, their callbacks (which will call
+ * {@link #setInAppResult} and {@link #setSubsResult}) should both take place on the UI thread, so
+ * we don't need to worry about any concurrency.
+ */
+public class BillingResultMerger {
+    private final SkuDetailsResponseListener mOnCombinedResult;
+
+    private @Nullable BillingResult mInAppResult;
+    private @Nullable List<SkuDetails> mInAppDetailsList;
+    private @Nullable BillingResult mSubsResult;
+    private @Nullable List<SkuDetails> mSubsDetailsList;
+
+    public BillingResultMerger(SkuDetailsResponseListener onCombinedResult) {
+        mOnCombinedResult = onCombinedResult;
+    }
+
+    public void setInAppResult(BillingResult result, @Nullable List<SkuDetails> detailsList) {
+        mInAppResult = result;
+        mInAppDetailsList = detailsList;
+
+        triggerIfReady();
+    }
+
+    public void setSubsResult(BillingResult result, @Nullable List<SkuDetails> detailsList) {
+        mSubsResult = result;
+        mSubsDetailsList = detailsList;
+
+        triggerIfReady();
+    }
+
+    private void triggerIfReady() {
+        if (mSubsResult == null || mInAppResult == null) return;
+
+        BillingResult result;
+        @Nullable List<SkuDetails> detailsList;
+        if (mSubsDetailsList == null || mSubsDetailsList.isEmpty()) {
+            // If one of the lists is null or empty, just use the results from the other call.
+            result = mInAppResult;
+            detailsList = mInAppDetailsList;
+        } else if (mInAppDetailsList == null || mInAppDetailsList.isEmpty()) {
+            result = mSubsResult;
+            detailsList = mSubsDetailsList;
+        } else {
+            // To merge the BillingResult:
+            // - If one call failed, pick that.
+            // - Arbitrarily return the INAPP result otherwise.
+            if (didSucceed(mInAppResult) && !didSucceed(mSubsResult)) {
+                result = mSubsResult;
+            } else {
+                result = mInAppResult;
+            }
+
+            // To merge the lists, we just combine them.
+            // Since we're in this branch, we know the two lists are non-null and non-empty.
+            detailsList = new ArrayList<>(mInAppDetailsList);
+            detailsList.addAll(mSubsDetailsList);
+        }
+
+        mOnCombinedResult.onSkuDetailsResponse(result, detailsList);
+    }
+
+    private static boolean didSucceed(BillingResult result) {
+        return result.getResponseCode() == BillingClient.BillingResponseCode.OK;
+    }
+}

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
@@ -17,6 +17,7 @@ package com.google.androidbrowserhelper.playbilling.digitalgoods;
 import android.app.Activity;
 
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
+import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeResponseListener;
@@ -85,8 +86,9 @@ public class ConnectedBillingWrapper implements BillingWrapper {
     }
 
     @Override
-    public void querySkuDetails(List<String> skus, SkuDetailsResponseListener callback) {
-        execute(() -> mInner.querySkuDetails(skus, callback));
+    public void querySkuDetails(@BillingClient.SkuType String skuType, List<String> skus,
+            SkuDetailsResponseListener callback) {
+        execute(() -> mInner.querySkuDetails(skuType, skus, callback));
     }
 
     @Override

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/GetDetailsCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/GetDetailsCall.java
@@ -16,9 +16,7 @@ package com.google.androidbrowserhelper.playbilling.digitalgoods;
 
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.util.Log;
 
-import com.android.billingclient.api.AcknowledgePurchaseParams;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.SkuDetails;
@@ -85,7 +83,10 @@ public class GetDetailsCall {
     public void call(BillingWrapper billing) {
         Logging.logGetDetailsCall(mItemIds);
 
-        billing.querySkuDetails(mItemIds, this::respond);
+        BillingResultMerger merger = new BillingResultMerger(this::respond);
+
+        billing.querySkuDetails(BillingClient.SkuType.INAPP, mItemIds, merger::setInAppResult);
+        billing.querySkuDetails(BillingClient.SkuType.SUBS, mItemIds, merger::setSubsResult);
     }
 
     /** Creates a Bundle that can be used with {@link #create}. For testing. */

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
@@ -17,6 +17,7 @@ package com.google.androidbrowserhelper.playbilling.provider;
 import android.app.Activity;
 
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
+import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeResponseListener;
@@ -44,7 +45,8 @@ public interface BillingWrapper {
     /**
      * Get {@link SkuDetails} objects for the provided SKUs.
      */
-    void querySkuDetails(List<String> skus, SkuDetailsResponseListener callback);
+    void querySkuDetails(@BillingClient.SkuType String skuType, List<String> skus,
+            SkuDetailsResponseListener callback);
 
     /**
      * Acknowledges that a purchase has occured.

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentActivity.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PaymentActivity.java
@@ -23,6 +23,7 @@ import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.SkuDetails;
+import com.google.androidbrowserhelper.playbilling.digitalgoods.BillingResultMerger;
 
 import java.util.Collections;
 import java.util.List;
@@ -81,7 +82,7 @@ public class PaymentActivity extends Activity implements BillingWrapper.Listener
     }
 
     public void onConnected() {
-        mWrapper.querySkuDetails(Collections.singletonList(mMethodData.sku),
+        BillingResultMerger merger = new BillingResultMerger(
                 (BillingResult result, List<SkuDetails> details) -> {
             if (details == null || details.isEmpty()) {
                 fail("Play Billing returned did not find SKUs.");
@@ -92,6 +93,10 @@ public class PaymentActivity extends Activity implements BillingWrapper.Listener
 
             fail("Payment attempt failed (have you already bought the item?).");
         });
+
+        List<String> ids = Collections.singletonList(mMethodData.sku);
+        mWrapper.querySkuDetails(BillingClient.SkuType.INAPP, ids, merger::setInAppResult);
+        mWrapper.querySkuDetails(BillingClient.SkuType.SUBS, ids, merger::setSubsResult);
     }
 
     @Override

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -71,11 +71,12 @@ public class PlayBillingWrapper implements BillingWrapper {
     }
 
     @Override
-    public void querySkuDetails(List<String> skus, SkuDetailsResponseListener callback) {
+    public void querySkuDetails(@BillingClient.SkuType String skuType, List<String> skus,
+            SkuDetailsResponseListener callback) {
         SkuDetailsParams params = SkuDetailsParams
                 .newBuilder()
                 .setSkusList(skus)
-                .setType(BillingClient.SkuType.INAPP)
+                .setType(skuType)
                 .build();
 
         mClient.querySkuDetailsAsync(params, callback);

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapperTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapperTest.java
@@ -38,7 +38,7 @@ public class ConnectedBillingWrapperTest {
 
     @Test
     public void delays_getDetailsCall() {
-        mConnectedWrapper.querySkuDetails(Collections.singletonList("id1"), null);
+        mConnectedWrapper.querySkuDetails("type", Collections.singletonList("id1"), null);
         assertNull(mInnerBillingWrapper.getQueriedSkuDetails());
 
         mInnerBillingWrapper.triggerConnected();
@@ -68,7 +68,7 @@ public class ConnectedBillingWrapperTest {
         mConnectedWrapper.connect(null);
         mInnerBillingWrapper.triggerConnected();
 
-        mConnectedWrapper.querySkuDetails(Collections.singletonList("id1"), null);
+        mConnectedWrapper.querySkuDetails("type", Collections.singletonList("id1"), null);
         assertEquals(mInnerBillingWrapper.getQueriedSkuDetails().get(0), "id1");
     }
 


### PR DESCRIPTION
Whenever the Play Billing API takes a SkuType as a parameter, we now call that method twice - once with in app purchases and once with subscriptions and combine the results.