### PR TITLE
Switch consume and acknowledge

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/AcknowledgeCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/AcknowledgeCall.java
@@ -78,9 +78,9 @@ public class AcknowledgeCall {
         Logging.logAckCall(purchaseToken, makeAvailableAgain);
 
         if (makeAvailableAgain) {
-            billing.acknowledge(purchaseToken, this::respond);
-        } else {
             billing.consume(purchaseToken, (result, token) -> respond(result));
+        } else {
+            billing.acknowledge(purchaseToken, this::respond);
         }
     }
 

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsTests.java
@@ -172,11 +172,11 @@ public class DigitalGoodsTests {
         mBillingWrapper.triggerConnected();
 
         if (makeAvailableAgain) {
-            assertEquals("id1", mBillingWrapper.getAcknowledgeToken());
-            mBillingWrapper.triggerAcknowledge(expectedResponseCode);
-        } else {
             assertEquals("id1", mBillingWrapper.getConsumeToken());
             mBillingWrapper.triggerConsume(expectedResponseCode, "?");
+        } else {
+            assertEquals("id1", mBillingWrapper.getAcknowledgeToken());
+            mBillingWrapper.triggerAcknowledge(expectedResponseCode);
         }
 
         assertTrue(callbackTriggered.await(5, TimeUnit.SECONDS));


### PR DESCRIPTION
Consume makes a purchase able to be repeatedly purchased, whereas acknowledge only charges for the purchase and prevents future purchases of the item.

PAIR=joycetoh8
TESTS=manual, updated unit tests