### PR TITLE
Add queryPurchases method to BillingWrapper.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
@@ -21,6 +21,7 @@ import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeResponseListener;
+import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsResponseListener;
 import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
@@ -89,6 +90,11 @@ public class ConnectedBillingWrapper implements BillingWrapper {
     public void querySkuDetails(@BillingClient.SkuType String skuType, List<String> skus,
             SkuDetailsResponseListener callback) {
         execute(() -> mInner.querySkuDetails(skuType, skus, callback));
+    }
+
+    @Override
+    public void queryPurchases(String skuType, QueryPurchasesListener callback) {
+        execute(() -> mInner.queryPurchases(skuType, callback));
     }
 
     @Override

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
@@ -21,8 +21,10 @@ import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeResponseListener;
+import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsResponseListener;
+import com.google.androidbrowserhelper.playbilling.digitalgoods.ConnectedBillingWrapper;
 
 import java.util.List;
 
@@ -39,6 +41,14 @@ public interface BillingWrapper {
         void onPurchaseFlowComplete(BillingResult result, String purchaseToken);
     }
 
+    /**
+     * Callback for {@link #queryPurchases} result.
+     */
+    interface QueryPurchasesListener {
+        /** Will be called after a call to {@link #queryPurchases}. */
+        void onQueryPurchasesResponse(Purchase.PurchasesResult result);
+    }
+
     /** Connect to the Play Billing client. */
     void connect(BillingClientStateListener callback);
 
@@ -47,6 +57,16 @@ public interface BillingWrapper {
      */
     void querySkuDetails(@BillingClient.SkuType String skuType, List<String> skus,
             SkuDetailsResponseListener callback);
+
+    /**
+     * Returns details for currently owned items.
+     *
+     * The corresponding method on {@link BillingClient} returns the results synchronously. We
+     * changed this to a callback based method to support the use case of
+     * {@link ConnectedBillingWrapper} which may have to connect to the BillingClient before
+     * returning.
+     */
+    void queryPurchases(@BillingClient.SkuType String skuType, QueryPurchasesListener callback);
 
     /**
      * Acknowledges that a purchase has occured.

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
@@ -74,6 +74,9 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     @Override
+    public void queryPurchases(String skuType, QueryPurchasesListener callback) { }
+
+    @Override
     public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
         mAcknowledgeToken = token;
         mPendingAcknowledgeCallback = callback;

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -83,6 +83,12 @@ public class PlayBillingWrapper implements BillingWrapper {
     }
 
     @Override
+    public void queryPurchases(@BillingClient.SkuType  String skuType,
+            QueryPurchasesListener callback) {
+        callback.onQueryPurchasesResponse(mClient.queryPurchases(skuType));
+    }
+
+    @Override
     public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
         AcknowledgePurchaseParams params = AcknowledgePurchaseParams
                 .newBuilder()


### PR DESCRIPTION
This PR is the first step towards implementing the `queryPurchases` method. It adds `queryPurchases` to BillingWrapper and its implementations.