### PR TITLE
Add a PurchaseDetails class.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConnectedBillingWrapper.java
@@ -21,6 +21,7 @@ import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeResponseListener;
+import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsResponseListener;
 import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
@@ -89,6 +90,11 @@ public class ConnectedBillingWrapper implements BillingWrapper {
     public void querySkuDetails(@BillingClient.SkuType String skuType, List<String> skus,
             SkuDetailsResponseListener callback) {
         execute(() -> mInner.querySkuDetails(skuType, skus, callback));
+    }
+
+    @Override
+    public void queryPurchases(String skuType, QueryPurchasesListener callback) {
+        execute(() -> mInner.queryPurchases(skuType, callback));
     }
 
     @Override

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetails.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetails.java
@@ -25,7 +25,7 @@ import androidx.annotation.Nullable;
  *
  * Its main purpose is to serialize {@link SkuDetails} into {@link Bundle}s in such a way that
  * Chromium can read it for the Digital Goods API. See:
- * https://source.chromium.org/chromium/chromium/src/+/master:chrome/android/java/src/org/chromium/chrome/browser/browserservices/digitalgoods/DigitalGoodsConverter.java;drc=a9e30a32540072b3b33d94435a42bef974b13a95
+ * https://source.chromium.org/chromium/chromium/src/+/master:chrome/android/java/src/org/chromium/chrome/browser/browserservices/digitalgoods/GetDetailsConverter.java;drc=a04f522e96fc0eaa0bbcb6eafa96d02aabe5452a
  */
 public class ItemDetails {
     private static final String KEY_DETAILS_ID = "itemDetails.id";
@@ -68,7 +68,7 @@ public class ItemDetails {
     }
 
     /**
-     * Creates this class from a PlayBilling {@link SkuDetails}.
+     * Creates this class from a Play Billing {@link SkuDetails}.
      */
     public static ItemDetails create(SkuDetails skuDetails) {
         return new ItemDetails(

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetails.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetails.java
@@ -1,0 +1,121 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import android.os.Bundle;
+
+import com.android.billingclient.api.Purchase;
+
+/**
+ * A data class representing a purchase from the Play Store.
+ *
+ * Its main purpose is to serialize {@link Purchase} into {@link Bundle}s in such a way that
+ * Chromium can read it for the Digital Goods API. See:
+ * https://source.chromium.org/chromium/chromium/src/+/master:chrome/android/java/src/org/chromium/chrome/browser/browserservices/digitalgoods/ListPurchasesConverter.java;drc=a04f522e96fc0eaa0bbcb6eafa96d02aabe5452a
+ */
+public class PurchaseDetails {
+    private static final String KEY_ITEM_ID = "listPurchases.itemId";
+    private static final String KEY_PURCHASE_TOKEN = "listPurchases.purchaseToken";
+    private static final String KEY_ACKNOWLEDGED = "listPurchases.acknowledged";
+    private static final String KEY_PURCHASE_STATE = "listPurchases.purchaseState";
+    private static final String KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH =
+            "listPurchases.purchaseTime";
+    private static final String KEY_WILL_AUTO_RENEW = "listPurchases.willAutoRenew";
+
+    static final int CHROMIUM_PURCHASE_STATE_UNKNOWN = 0;
+    static final int CHROMIUM_PURCHASE_STATE_PURCHASED = 1;
+    static final int CHROMIUM_PURCHASE_STATE_PENDING = 2;
+
+    /**
+     * This is the id according to Chromium, which corresponds {@link Purchase#getSku}, not to
+     * {@link Purchase#getOrderId}.
+     */
+    public final String id;
+    public final String purchaseToken;
+    public final boolean acknowledged;
+    public final int purchaseState;
+    public final long purchaseTimeMicrosecondsPastUnixEpoch;
+    public final boolean willAutoRenew;
+
+    private PurchaseDetails(String id, String purchaseToken, boolean acknowledged,
+            int purchaseState, long purchaseTimeMicrosecondsPastUnixEpoch, boolean willAutoRenew) {
+        this.id = id;
+        this.purchaseToken = purchaseToken;
+        this.acknowledged = acknowledged;
+        this.purchaseState = purchaseState;
+        this.purchaseTimeMicrosecondsPastUnixEpoch = purchaseTimeMicrosecondsPastUnixEpoch;
+        this.willAutoRenew = willAutoRenew;
+    }
+
+    /**
+     * Creates this class from a Play Billing {@link Purchase}.
+     */
+    public static PurchaseDetails create(Purchase purchase) {
+        return new PurchaseDetails(
+                purchase.getSku(),
+                purchase.getPurchaseToken(),
+                purchase.isAcknowledged(),
+                toChromiumPurchaseState(purchase.getPurchaseState()),
+                millisecondsToMicroseconds(purchase.getPurchaseTime()),
+                purchase.isAutoRenewing()
+        );
+    }
+
+    /**
+     * Creates this class from a {@link Bundle} previously created by {@link #toBundle}.
+     */
+    public static PurchaseDetails create(Bundle bundle) {
+        String id = bundle.getString(KEY_ITEM_ID);
+        String token = bundle.getString(KEY_PURCHASE_TOKEN);
+        boolean acknowledged = bundle.getBoolean(KEY_ACKNOWLEDGED);
+        int state = bundle.getInt(KEY_PURCHASE_STATE);
+        long timeMsPastUnixEpoch = bundle.getLong(KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH);
+        boolean willAutoRenew = bundle.getBoolean(KEY_WILL_AUTO_RENEW);
+        return new PurchaseDetails(id, token, acknowledged, state, timeMsPastUnixEpoch,
+                willAutoRenew);
+    }
+
+    /**
+     * Serializes this object to a {@link Bundle} for sending to Chromium.
+     */
+    public Bundle toBundle() {
+        Bundle bundle = new Bundle();
+
+        bundle.putString(KEY_ITEM_ID, id);
+        bundle.putString(KEY_PURCHASE_TOKEN, purchaseToken);
+        bundle.putBoolean(KEY_ACKNOWLEDGED, acknowledged);
+        bundle.putInt(KEY_PURCHASE_STATE, purchaseState);
+        bundle.putLong(KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH,
+                purchaseTimeMicrosecondsPastUnixEpoch);
+        bundle.putBoolean(KEY_WILL_AUTO_RENEW, willAutoRenew);
+
+        return bundle;
+    }
+
+    private static long millisecondsToMicroseconds(long milliseconds) {
+        return milliseconds * 1000;
+    }
+
+    private static int toChromiumPurchaseState(@Purchase.PurchaseState int purchaseState) {
+        switch (purchaseState) {
+            case Purchase.PurchaseState.PENDING:
+                return CHROMIUM_PURCHASE_STATE_PENDING;
+            case Purchase.PurchaseState.PURCHASED:
+                return CHROMIUM_PURCHASE_STATE_PURCHASED;
+            default:
+                return CHROMIUM_PURCHASE_STATE_UNKNOWN;
+        }
+    }
+}

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetails.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetails.java
@@ -39,7 +39,7 @@ public class PurchaseDetails {
     static final int CHROMIUM_PURCHASE_STATE_PENDING = 2;
 
     /**
-     * This is the id according to Chromium, which corresponds {@link Purchase#getSku}, not to
+     * This is the id according to Chromium, which corresponds to {@link Purchase#getSku}, not to
      * {@link Purchase#getOrderId}.
      */
     public final String id;

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/BillingWrapper.java
@@ -21,8 +21,10 @@ import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeResponseListener;
+import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsResponseListener;
+import com.google.androidbrowserhelper.playbilling.digitalgoods.ConnectedBillingWrapper;
 
 import java.util.List;
 
@@ -39,6 +41,14 @@ public interface BillingWrapper {
         void onPurchaseFlowComplete(BillingResult result, String purchaseToken);
     }
 
+    /**
+     * Callback for {@link #queryPurchases} result.
+     */
+    interface QueryPurchasesListener {
+        /** Will be called after a call to {@link #queryPurchases}. */
+        void onQueryPurchasesResponse(Purchase.PurchasesResult result);
+    }
+
     /** Connect to the Play Billing client. */
     void connect(BillingClientStateListener callback);
 
@@ -47,6 +57,16 @@ public interface BillingWrapper {
      */
     void querySkuDetails(@BillingClient.SkuType String skuType, List<String> skus,
             SkuDetailsResponseListener callback);
+
+    /**
+     * Returns details for currently owned items.
+     *
+     * The corresponding method on {@link BillingClient} returns the results synchronously. We
+     * changed this to a callback based method to support the use case of
+     * {@link ConnectedBillingWrapper} which may have to connect to the BillingClient before
+     * returning.
+     */
+    void queryPurchases(@BillingClient.SkuType String skuType, QueryPurchasesListener callback);
 
     /**
      * Acknowledges that a purchase has occured.

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
@@ -74,6 +74,9 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     @Override
+    public void queryPurchases(String skuType, QueryPurchasesListener callback) { }
+
+    @Override
     public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
         mAcknowledgeToken = token;
         mPendingAcknowledgeCallback = callback;

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -83,6 +83,12 @@ public class PlayBillingWrapper implements BillingWrapper {
     }
 
     @Override
+    public void queryPurchases(@BillingClient.SkuType  String skuType,
+            QueryPurchasesListener callback) {
+        callback.onQueryPurchasesResponse(mClient.queryPurchases(skuType));
+    }
+
+    @Override
     public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
         AcknowledgePurchaseParams params = AcknowledgePurchaseParams
                 .newBuilder()

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetailsTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetailsTest.java
@@ -25,6 +25,9 @@ import org.robolectric.annotation.internal.DoNotInstrument;
 
 import androidx.annotation.Nullable;
 
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addField;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addFieldWithoutLeadingComma;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addOptionalField;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
@@ -115,24 +118,4 @@ public class ItemDetailsTest {
         b.append("}");
         return b.toString();
     }
-
-    private static void addFieldWithoutLeadingComma(StringBuilder b, String name, Object value) {
-        // "name" = "value"
-        b.append('"');
-        b.append(name);
-        b.append("\" = \"");
-        b.append(value.toString());
-        b.append('"');
-    }
-
-    private static void addField(StringBuilder b, String name, Object field) {
-        b.append(',');
-        addFieldWithoutLeadingComma(b, name, field);
-    }
-
-    private static void addOptionalField(StringBuilder b, String name, @Nullable Object field) {
-        if (field == null) return;
-        addField(b, name, field);
-    }
-
 }

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/JsonUtils.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/JsonUtils.java
@@ -1,0 +1,55 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import androidx.annotation.Nullable;
+
+/**
+ * A collection of some utility functions for creating JSON strings. We need this because some Play
+ * Billing types take JSON representations of their objects in the constructor.
+ */
+public class JsonUtils {
+    private JsonUtils() {}
+
+    /**
+     * Adds a JSON field of the given name and value. Does not add any separating commas, so use
+     * this for the initial field.
+     */
+    public static void addFieldWithoutLeadingComma(StringBuilder b, String name, Object value) {
+        // "name" = "value"
+        b.append('"');
+        b.append(name);
+        b.append("\" = \"");
+        b.append(value.toString());
+        b.append('"');
+    }
+
+    /**
+     * Adds a JSON field of the given name and value. Adds a comma before the field.
+     */
+    public static void addField(StringBuilder b, String name, Object value) {
+        b.append(',');
+        addFieldWithoutLeadingComma(b, name, value);
+    }
+
+    /**
+     * Adds the provided field if the value is not {@code null}.
+     */
+    public static void addOptionalField(StringBuilder b, String name, @Nullable Object value) {
+        if (value == null) return;
+        addField(b, name, value);
+    }
+}
+

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetailsTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetailsTest.java
@@ -1,0 +1,103 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import com.android.billingclient.api.Purchase;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.internal.DoNotInstrument;
+
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addField;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addFieldWithoutLeadingComma;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addOptionalField;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.PurchaseDetails.CHROMIUM_PURCHASE_STATE_PENDING;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+@DoNotInstrument
+@Config(manifest = Config.NONE)
+public class PurchaseDetailsTest {
+    @Test
+    public void create() throws JSONException {
+        Purchase purchase = new Purchase(createPurchaseJson("id", "token", true,
+                Purchase.PurchaseState.PENDING, 123_000, true), "");
+
+        PurchaseDetails details = PurchaseDetails.create(purchase);
+
+        assertPurchaseDetails(details,
+                "id",
+                "token",
+                true,
+                CHROMIUM_PURCHASE_STATE_PENDING,  // Converted to the Chromium type.
+                123_000_000,  // Converted to microseconds.
+                true);
+    }
+
+    @Test
+    public void bundleConversion() throws JSONException {
+        Purchase purchase = new Purchase(createPurchaseJson("id", "token", true,
+                Purchase.PurchaseState.PENDING, 123_000, true), "");
+
+        PurchaseDetails details =
+                PurchaseDetails.create(PurchaseDetails.create(purchase).toBundle());
+
+        assertPurchaseDetails(details,
+                "id",
+                "token",
+                true,
+                CHROMIUM_PURCHASE_STATE_PENDING,  // Converted to the Chromium type.
+                123_000_000,  // Converted to microseconds.
+                true);
+    }
+
+    private static void assertPurchaseDetails(PurchaseDetails details, String id, String token,
+            boolean acknowledged, int state, long purchaseTimeMicrosecondsPastUnixEpoch,
+            boolean willAutoRenew) {
+        assertEquals(details.id, id);
+        assertEquals(details.purchaseToken, token);
+        assertEquals(details.acknowledged, acknowledged);
+        assertEquals(details.purchaseState, state);
+        assertEquals(details.purchaseTimeMicrosecondsPastUnixEpoch,
+                purchaseTimeMicrosecondsPastUnixEpoch);
+        assertEquals(details.willAutoRenew, willAutoRenew);
+    }
+
+    private static String createPurchaseJson(String id, String purchaseToken, boolean acknowledged,
+            int purchaseState, long purchaseTime, boolean willAutoRenew) {
+        // In the input JSON to a Play Billing Purchase, a PurchaseState of 4 corresponds to
+        // PENDING and a PurchaseState of anything else corresponds to PURCHASED.
+        assert purchaseState == Purchase.PurchaseState.PENDING ||
+                purchaseState == Purchase.PurchaseState.PURCHASED;
+        int fixedPurchaseState = purchaseState == Purchase.PurchaseState.PENDING ? 4 : 0;
+
+        StringBuilder b = new StringBuilder();
+
+        b.append("{");
+
+        addFieldWithoutLeadingComma(b, "productId", id);
+        addField(b, "token", purchaseToken);
+        addField(b, "acknowledged", acknowledged);
+        addField(b, "purchaseState", fixedPurchaseState);
+        addField(b, "purchaseTime", purchaseTime);
+        addField(b, "autoRenewing", willAutoRenew);
+
+        b.append("}");
+        return b.toString();
+    }
+}


### PR DESCRIPTION
This PR adds a data class, similar to `ItemDetails` that is responsible for serializing the Play Billing `Purchase` class and converting its data to types that Chromium accepts.