### PR TITLE
Add ListPurchases functionality.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/BillingResultMerger.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/BillingResultMerger.java
@@ -42,7 +42,7 @@ public class BillingResultMerger<T> {
     private @Nullable List<T> mSubsResultsList;
 
     public interface ResultListener<T> {
-        void onResult(BillingResult responseCode, List<T> combinedResult);
+        void onResult(BillingResult responseCode, @Nullable List<T> combinedResult);
     }
 
     public BillingResultMerger(ResultListener<T> onCombinedResult) {

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
@@ -67,7 +67,7 @@ public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
                 acknowledgeCall.call(mWrapper);
                 return true;
             case ListPurchasesCall.COMMAND_NAME:
-                ListPurchasesCall listPurchasesCall = ListPurchasesCall.create(args, callback);
+                ListPurchasesCall listPurchasesCall = ListPurchasesCall.create(callback);
                 if (listPurchasesCall == null) break;
                 listPurchasesCall.call(mWrapper);
                 return true;

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
@@ -66,6 +66,11 @@ public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
                 if (acknowledgeCall == null) break;
                 acknowledgeCall.call(mWrapper);
                 return true;
+            case ListPurchasesCall.COMMAND_NAME:
+                ListPurchasesCall listPurchasesCall = ListPurchasesCall.create(args, callback);
+                if (listPurchasesCall == null) break;
+                listPurchasesCall.call(mWrapper);
+                return true;
         }
 
         Logging.logUnknownCommand(commandName);

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/GetDetailsCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/GetDetailsCall.java
@@ -29,7 +29,7 @@ import androidx.annotation.Nullable;
 
 /**
  * A class for parsing Digital Goods API calls from the browser and converting them into a format
- * suitable for calling the Play Biling library.
+ * suitable for calling the Play Billing library.
  */
 public class GetDetailsCall {
     public static final String COMMAND_NAME = "getDetails";
@@ -60,7 +60,7 @@ public class GetDetailsCall {
     }
 
     /** Calls the callback provided in the constructor with serialized forms of the parameters. */
-    private void respond(BillingResult result, List<SkuDetails> detailsList) {
+    private void respond(BillingResult result, @Nullable List<SkuDetails> detailsList) {
         Logging.logGetDetailsResponse(result);
 
         Parcelable[] parcelables = new Parcelable[0];

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ListPurchasesCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ListPurchasesCall.java
@@ -1,0 +1,85 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import android.os.Bundle;
+import android.os.Parcelable;
+
+import com.android.billingclient.api.BillingClient;
+import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.Purchase;
+import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
+
+import java.util.List;
+
+import androidx.annotation.Nullable;
+
+/**
+ * A class for parsing Digital Goods API calls from the browser and converting them into a format
+ * suitable for calling the Play Billing library.
+ */
+public class ListPurchasesCall {
+    public static final String COMMAND_NAME = "listPurchases";
+
+    static final String RESPONSE_COMMAND = "listPurchases.response";
+    static final String KEY_PURCHASES_LIST = "listPurchases.purchasesList";
+    static final String KEY_RESPONSE_CODE = "listPurchases.responseCode";
+
+    private final DigitalGoodsCallback mCallback;
+
+    private ListPurchasesCall(DigitalGoodsCallback callback) {
+        mCallback = callback;
+    }
+
+    /** Creates this class from a {@link Bundle}, returns {@code null} if the Bundle is invalid. */
+    @Nullable
+    public static ListPurchasesCall create(@Nullable Bundle args,
+            @Nullable DigitalGoodsCallback callback) {
+        if (args == null || callback == null) return null;
+
+        return new ListPurchasesCall(callback);
+    }
+
+    /* Calls the appropriate method on {@link BillingWrapper}. */
+    public void call(BillingWrapper billing) {
+        Logging.logListPurchasesCall();
+
+        BillingResultMerger<Purchase> merger = new BillingResultMerger<>(this::respond);
+
+        billing.queryPurchases(BillingClient.SkuType.INAPP, (result ->
+                merger.setInAppResult(result.getBillingResult(), result.getPurchasesList())));
+        billing.queryPurchases(BillingClient.SkuType.SUBS, (result ->
+                merger.setSubsResult(result.getBillingResult(), result.getPurchasesList())));
+    }
+
+    private void respond(BillingResult billingResult, @Nullable List<Purchase> purchaseList) {
+        Logging.logListPurchasesResult(billingResult);
+
+        Parcelable[] parcelables = new Parcelable[0];
+        if (purchaseList != null) {
+            parcelables = new Parcelable[purchaseList.size()];
+
+            int index = 0;
+            for (Purchase purchase : purchaseList) {
+                parcelables[index++] = PurchaseDetails.create(purchase).toBundle();
+            }
+        }
+
+        Bundle args = new Bundle();
+        args.putInt(KEY_RESPONSE_CODE, billingResult.getResponseCode());
+        args.putParcelableArray(KEY_PURCHASES_LIST, parcelables);
+        mCallback.run(RESPONSE_COMMAND, args);
+    }
+}

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ListPurchasesCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ListPurchasesCall.java
@@ -43,11 +43,10 @@ public class ListPurchasesCall {
         mCallback = callback;
     }
 
-    /** Creates this class from a {@link Bundle}, returns {@code null} if the Bundle is invalid. */
+    /** Creates this class from a {@link Bundle}. */
     @Nullable
-    public static ListPurchasesCall create(@Nullable Bundle args,
-            @Nullable DigitalGoodsCallback callback) {
-        if (args == null || callback == null) return null;
+    public static ListPurchasesCall create(@Nullable DigitalGoodsCallback callback) {
+        if (callback == null) return null;
 
         return new ListPurchasesCall(callback);
     }
@@ -58,10 +57,10 @@ public class ListPurchasesCall {
 
         BillingResultMerger<Purchase> merger = new BillingResultMerger<>(this::respond);
 
-        billing.queryPurchases(BillingClient.SkuType.INAPP, (result ->
-                merger.setInAppResult(result.getBillingResult(), result.getPurchasesList())));
-        billing.queryPurchases(BillingClient.SkuType.SUBS, (result ->
-                merger.setSubsResult(result.getBillingResult(), result.getPurchasesList())));
+        billing.queryPurchases(BillingClient.SkuType.INAPP, result ->
+                merger.setInAppResult(result.getBillingResult(), result.getPurchasesList()));
+        billing.queryPurchases(BillingClient.SkuType.SUBS, result ->
+                merger.setSubsResult(result.getBillingResult(), result.getPurchasesList()));
     }
 
     private void respond(BillingResult billingResult, @Nullable List<Purchase> purchaseList) {

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/Logging.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/Logging.java
@@ -62,6 +62,14 @@ public class Logging {
         logResult(result, "GetDetails returned:");
     }
 
+    static void logListPurchasesCall() {
+        Log.d(TAG, "Calling listPurchases");
+    }
+
+    static void logListPurchasesResult(BillingResult result) {
+        logResult(result, "ListPurchases returned:");
+    }
+
     private static void logResult(BillingResult result, String message) {
         int responseCode = result.getResponseCode();
 

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetailsTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetailsTest.java
@@ -80,7 +80,7 @@ public class ItemDetailsTest {
                 "0.000000");
     }
 
-    private static void assertItemDetails(ItemDetails item, String id, String title,
+    static void assertItemDetails(ItemDetails item, String id, String title,
             String description, String currency, String value, String subscriptionPeriod,
             String freeTrialPeriod, String introductoryPricePeriod,
             String introductoryPriceCurrency, String introductoryPriceValue) {
@@ -96,7 +96,7 @@ public class ItemDetailsTest {
         assertEquals(item.introductoryPriceValue, introductoryPriceValue);
     }
 
-    private static String createSkuDetailsJson(String id, String title, String description,
+    static String createSkuDetailsJson(String id, String title, String description,
             String currency, long value, @Nullable String subscriptionPeriod,
             @Nullable String freeTrialPeriod, @Nullable String introductoryPricePeriod,
             @Nullable Long introductoryPriceValue) {

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetailsTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetailsTest.java
@@ -66,7 +66,7 @@ public class PurchaseDetailsTest {
                 true);
     }
 
-    private static void assertPurchaseDetails(PurchaseDetails details, String id, String token,
+    static void assertPurchaseDetails(PurchaseDetails details, String id, String token,
             boolean acknowledged, int state, long purchaseTimeMicrosecondsPastUnixEpoch,
             boolean willAutoRenew) {
         assertEquals(details.id, id);
@@ -78,7 +78,7 @@ public class PurchaseDetailsTest {
         assertEquals(details.willAutoRenew, willAutoRenew);
     }
 
-    private static String createPurchaseJson(String id, String purchaseToken, boolean acknowledged,
+    static String createPurchaseJson(String id, String purchaseToken, boolean acknowledged,
             int purchaseState, long purchaseTime, boolean willAutoRenew) {
         // In the input JSON to a Play Billing Purchase, a PurchaseState of 4 corresponds to
         // PENDING and a PurchaseState of anything else corresponds to PURCHASED.


### PR DESCRIPTION
This PR completes the ListPurchases functionality, allowing the browser to get the TWA shell to call BillingClient#queryPurchases on its behalf.