### PR TITLE
Update Play Billing library.

### DIFF
--- a/playbilling/build.gradle
+++ b/playbilling/build.gradle
@@ -50,8 +50,7 @@ dependencies {
     api 'androidx.browser:browser:1.3.0-alpha06'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'com.android.billingclient:billing:2.1.0'
+    implementation 'com.android.billingclient:billing:3.0.1'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.0.1'

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetailsTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ItemDetailsTest.java
@@ -14,6 +14,7 @@
 
 package com.google.androidbrowserhelper.playbilling.digitalgoods;
 
+import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.SkuDetails;
 
 import org.json.JSONException;
@@ -114,6 +115,10 @@ public class ItemDetailsTest {
         addOptionalField(b, "freeTrialPeriod", freeTrialPeriod);
         addOptionalField(b, "introductoryPricePeriod", introductoryPricePeriod);
         addOptionalField(b, "introductoryPriceAmountMicros", introductoryPriceValue);
+
+        // The Play Billing library requires that all SkuDetails have a type, but we don't use it
+        // in our testing, so just set it to an arbitrary type.
+        addField(b, "type", BillingClient.SkuType.INAPP);
 
         b.append("}");
         return b.toString();


### PR DESCRIPTION
This PR updates the Play Billing library dependency to version 3.0.1. It also removes an unused Kotlin standard library dependency and updates some tests that were broken by the Play Billing upgrade.