### PR TITLE
Set ARC_PAYMENT_APP as a trusted package.

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -251,9 +251,15 @@ public class TwaLauncher {
         FocusActivity.addToIntent(intent, mContext);
         ContextCompat.startActivity(mContext, intent, null);
 
-        // Remember who we connect to as the package that is allowed to delegate notifications
-        // to us.
-        mTokenStore.store(Token.create(mProviderPackage, mContext.getPackageManager()));
+        if (ChromeOsSupport.isRunningOnArc(mContext.getPackageManager())) {
+            // If running in ARC++ on Chrome OS, set the system package as trusted.
+            mTokenStore.store(Token.create(ChromeOsSupport.ARC_PAYMENT_APP,
+                    mContext.getPackageManager()));
+        } else {
+            // Remember who we connect to as the package that is allowed to delegate notifications
+            // to us.
+            mTokenStore.store(Token.create(mProviderPackage, mContext.getPackageManager()));
+        }
 
         if (completionCallback != null) {
             completionCallback.run();


### PR DESCRIPTION
Set the ARC_PAYMENT_APP package name to be trusted so that Chrome OS can query the digital goods API.