### PR TITLE
Move Token storing code to where ChromeOS will hit it too.

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -20,6 +20,8 @@ import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
 
+import com.google.androidbrowserhelper.trusted.splashscreens.SplashScreenStrategy;
+
 import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
@@ -31,9 +33,6 @@ import androidx.browser.trusted.Token;
 import androidx.browser.trusted.TokenStore;
 import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
 import androidx.core.content.ContextCompat;
-
-import com.google.androidbrowserhelper.trusted.ChromeOsSupport;
-import com.google.androidbrowserhelper.trusted.splashscreens.SplashScreenStrategy;
 
 /**
  * Encapsulates the steps necessary to launch a Trusted Web Activity, such as establishing a
@@ -173,6 +172,16 @@ public class TwaLauncher {
         } else {
             fallbackStrategy.launch(mContext, twaBuilder, mProviderPackage, completionCallback);
         }
+
+        // Remember who we connect to as the package that is allowed to delegate notifications
+        // to us.
+        if (ChromeOsSupport.isRunningOnArc(mContext.getPackageManager())) {
+            // If running in ARC++ on Chrome OS, set the system package as trusted.
+            mTokenStore.store(
+                    Token.create(ChromeOsSupport.ARC_PAYMENT_APP, mContext.getPackageManager()));
+        } else {
+            mTokenStore.store(Token.create(mProviderPackage, mContext.getPackageManager()));
+        }
     }
 
     /**
@@ -250,16 +259,6 @@ public class TwaLauncher {
         Intent intent = builder.build(mSession).getIntent();
         FocusActivity.addToIntent(intent, mContext);
         ContextCompat.startActivity(mContext, intent, null);
-
-        if (ChromeOsSupport.isRunningOnArc(mContext.getPackageManager())) {
-            // If running in ARC++ on Chrome OS, set the system package as trusted.
-            mTokenStore.store(Token.create(ChromeOsSupport.ARC_PAYMENT_APP,
-                    mContext.getPackageManager()));
-        } else {
-            // Remember who we connect to as the package that is allowed to delegate notifications
-            // to us.
-            mTokenStore.store(Token.create(mProviderPackage, mContext.getPackageManager()));
-        }
 
         if (completionCallback != null) {
             completionCallback.run();

--- a/demos/twa-play-billing/build.gradle
+++ b/demos/twa-play-billing/build.gradle
@@ -27,8 +27,8 @@ android {
         applicationId appId
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 6
-        versionName "6.0"
+        versionCode 9
+        versionName "9.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {

--- a/demos/twa-play-billing/src/main/res/values/strings.xml
+++ b/demos/twa-play-billing/src/main/res/values/strings.xml
@@ -37,9 +37,7 @@ Version 4:\n
 - Add subscription fields to GetDetails result.\n
 - Implement ListPurchases.\n
 - Update Play Billing library to 3.0.1.\n\n
-Version 5:\n
-- Allow launching as a TWA on ChromeOS.\n\n
-Version 6:\n
-- Verify the ARC service as the browser on ChromeOS.
+Version 5-9:\n
+- Various attempts to make this work on ChromeOS.
     </string>
 </resources>


### PR DESCRIPTION
This PR moves the code for setting the verified provider so that it now executes no matter what the launch mode is.

Previously it only executed when the launch mode was TWA, which mean that it wasn't executed when launched on ChromeOS (which from the point of view of the `TwaLauncher` is launched as a Custom Tab). Now it should be run for ChromeOS as well.