### PR TITLE
Improves the Custom tabs / Headers demo

### DIFF
--- a/demos/custom-tabs-headers/README.md
+++ b/demos/custom-tabs-headers/README.md
@@ -1,0 +1,19 @@
+Custom Tabs Custom Headers Demo
+===============================
+
+This demo shows how to add custom headers to a web request when opening an URL with Custom Tabs.
+
+Adding custom headers only works when the developer owns both the application using Custom Tabs and
+the origin being opened, and can prove ownership via [Digital Asset Links][2].
+
+Check out [this blogpost][1] for more details on how the implementation works and steps to setup
+the Digital Asset Links validation.
+
+:bangbang: **Important:** This project is using a demo page hosted at Glitch. However, the demo will
+only work if the Digital Asset Links validation is successful. So, when testing on your computer,
+remix the project at https://glitch.com/edit/#!/custom-tabs-custom-he, edit the file under
+`public/.well-known/assetlinks.json` with your own SHA-256 fingerprint (use Tools > Terminal
+to find and edit the file), and update the opened by the application.
+
+[1]: https://developer.chrome.com/docs/android/custom-tabs/headers/
+[2]: https://developers.google.com/digital-asset-links

--- a/demos/custom-tabs-headers/README.md
+++ b/demos/custom-tabs-headers/README.md
@@ -13,7 +13,7 @@ the Digital Asset Links validation.
 only work if the Digital Asset Links validation is successful. So, when testing on your computer,
 remix the project at https://glitch.com/edit/#!/custom-tabs-custom-he, edit the file under
 `public/.well-known/assetlinks.json` with your own SHA-256 fingerprint (use Tools > Terminal
-to find and edit the file), and update the opened by the application.
+to find and edit the file), and update the URL opened by the application.
 
 [1]: https://developer.chrome.com/docs/android/custom-tabs/headers/
 [2]: https://developers.google.com/digital-asset-links

--- a/demos/custom-tabs-headers/src/main/java/com/google/androidbrowserhelper/demos/customtabsheaders/MainActivity.java
+++ b/demos/custom-tabs-headers/src/main/java/com/google/androidbrowserhelper/demos/customtabsheaders/MainActivity.java
@@ -83,10 +83,11 @@ public class MainActivity extends Activity {
 
         //Add package names for other browsers that support Custom Tabs and custom headers.
         List<String> packageNames = Arrays.asList(
-                "com.android.chrome",
-                "com.chrome.beta",
+                "com.google.android.apps.chrome",
+                "com.chrome.canary",
                 "com.chrome.dev",
-                "com.chrome.canary"
+                "com.chrome.beta",
+                "com.android.chrome"
         );
         String packageName =
                 CustomTabsClient.getPackageName(MainActivity.this, packageNames, false);

--- a/demos/custom-tabs-headers/src/main/java/com/google/androidbrowserhelper/demos/customtabsheaders/MainActivity.java
+++ b/demos/custom-tabs-headers/src/main/java/com/google/androidbrowserhelper/demos/customtabsheaders/MainActivity.java
@@ -27,15 +27,22 @@ import androidx.browser.customtabs.CustomTabsSession;
 
 import android.app.Activity;
 import android.content.ComponentName;
-import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.Browser;
 import android.widget.Button;
 import android.widget.Toast;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class MainActivity extends Activity {
-    private static final Uri URL = Uri.parse("https://padr31.github.io/");
+    // This project is using a demo page hosted at Glitch. However, the demo will only work if the
+    // Digital Asset Links validation is successful. So, when testing on your computer, remix the
+    // project at https://glitch.com/edit/#!/custom-tabs-custom-he, edit the file under
+    // `public/.well-known/assetlinks.json` with your own SHA-256 fingerprint (use Tools > Terminal
+    // to find and edit the file), and update the URL below to the new project.
+    private static final Uri URL = Uri.parse("https://custom-tabs-custom-he.glitch.me/");
 
     private CustomTabsSession mSession;
     private CustomTabsServiceConnection mConnection;
@@ -50,7 +57,7 @@ public class MainActivity extends Activity {
         CustomTabsCallback callback = new CustomTabsCallback() {
             @Override
             public void onRelationshipValidationResult(int relation, @NonNull Uri requestedOrigin,
-                    boolean result, @Nullable Bundle extras) {
+                                                       boolean result, @Nullable Bundle extras) {
                 // Can launch custom tabs intent after session was validated as the same origin.
                 mExtraButton.setEnabled(true);
             }
@@ -60,7 +67,7 @@ public class MainActivity extends Activity {
         mConnection = new CustomTabsServiceConnection() {
             @Override
             public void onCustomTabsServiceConnected(@NonNull ComponentName name,
-                    @NonNull CustomTabsClient client) {
+                                                     @NonNull CustomTabsClient client) {
                 // Create session after service connected.
                 mSession = client.newSession(callback);
                 client.warmup(0);
@@ -74,10 +81,18 @@ public class MainActivity extends Activity {
             }
         };
 
-        String packageName = CustomTabsClient.getPackageName(MainActivity.this, null);
+        //Add package names for other browsers that support Custom Tabs and custom headers.
+        List<String> packageNames = Arrays.asList(
+                "com.android.chrome",
+                "com.chrome.beta",
+                "com.chrome.dev",
+                "com.chrome.canary"
+        );
+        String packageName =
+                CustomTabsClient.getPackageName(MainActivity.this, packageNames, false);
         if (packageName == null) {
             Toast.makeText(getApplicationContext(), "Package name is null.", Toast.LENGTH_SHORT)
-                .show();
+                    .show();
         } else {
             // Bind the custom tabs service connection.
             CustomTabsClient.bindCustomTabsService(this, packageName, mConnection);
@@ -100,9 +115,13 @@ public class MainActivity extends Activity {
     @Override
     protected void onStop() {
         super.onStop();
-        if (mConnection == null) return;
-        unbindService(mConnection);
-        mConnection = null;
+
+        // Unbind from the service if we connected successfully and clear the session.
+        if (mSession != null) {
+            unbindService(mConnection);
+            mConnection = null;
+            mSession = null;
+        }
         mExtraButton.setEnabled(false);
     }
 


### PR DESCRIPTION
- Adds a default list of browsers when calling `getPackageName()`
otherwise the method only returns a browser if a default is set
and it supports Custom Tabs.
- Modify `onStop()` to only call `unbindService()` if `mSession`
is not null. This is because `mConnection` is always non-null, as
it is set unconditionally on `onStart()`.
- Adds a README.md file with pointers to blogpost and instructions.
- Adds extra comments with instructions to the code.