### PR TITLE
Prevent relaunching the TWA on subsequent Launcher launches.

### DIFF
--- a/demos/twa-basic/src/main/AndroidManifest.xml
+++ b/demos/twa-basic/src/main/AndroidManifest.xml
@@ -26,8 +26,7 @@
             android:resource="@string/asset_statements" />
 
         <activity android:name="com.google.androidbrowserhelper.trusted.LauncherActivity"
-            android:label="@string/app_name"
-            android:screenOrientation="landscape">
+            android:label="@string/app_name" >
             <meta-data android:name="android.support.customtabs.trusted.DEFAULT_URL"
                 android:value="https://airhorner.com" />
 


### PR DESCRIPTION
I believe this should fix https://github.com/GoogleChromeLabs/bubblewrap/issues/469 .

See comment in LauncherActivity#onCreate for more info.