### PR TITLE
Demo uses setUrlBarHidingEnabled()

### DIFF
--- a/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomUIActivity.java
+++ b/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomUIActivity.java
@@ -148,9 +148,7 @@ public class CustomUIActivity extends AppCompatActivity implements View.OnClickL
 
         intentBuilder.setShowTitle(mShowTitleCheckBox.isChecked());
 
-        if (mAutoHideAppBarCheckbox.isChecked()) {
-            intentBuilder.enableUrlBarHiding();
-        }
+        intentBuilder.setUrlBarHidingEnabled(mAutoHideAppBarCheckbox.isChecked());
 
         if (mCustomBackButtonCheckBox.isChecked()) {
             intentBuilder.setCloseButtonIcon(toBitmap(getDrawable(R.drawable.ic_arrow_back)));


### PR DESCRIPTION
- Replaces `enableUrlBarHiding()` with
`setUrlBarHidingEnabled(boolean)`, as the first one has been
deprecated and replaced by the latter.