### PR TITLE
Fixes asynch launchTwa freezing splash screens

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -155,6 +155,18 @@ public class LauncherActivity extends Activity {
             return;
         }
 
+        mMetadata = LauncherActivityMetadata.parse(this);
+
+        if (splashScreenNeeded()) {
+            mSplashScreenStrategy = new PwaWrapperSplashScreenStrategy(this,
+                    mMetadata.splashImageDrawableId,
+                    getColorCompat(mMetadata.splashScreenBackgroundColorId),
+                    getSplashImageScaleType(),
+                    getSplashImageTransformationMatrix(),
+                    mMetadata.splashScreenFadeOutDurationMillis,
+                    mMetadata.fileProviderAuthority);
+        }
+
         if (shouldLaunchImmediately()) {
             launchTwa();
         }
@@ -175,16 +187,12 @@ public class LauncherActivity extends Activity {
      * {@link #shouldLaunchImmediately()} returns {@code false}.
      */
     protected void launchTwa() {
-        mMetadata = LauncherActivityMetadata.parse(this);
-
-        if (splashScreenNeeded()) {
-            mSplashScreenStrategy = new PwaWrapperSplashScreenStrategy(this,
-                    mMetadata.splashImageDrawableId,
-                    getColorCompat(mMetadata.splashScreenBackgroundColorId),
-                    getSplashImageScaleType(),
-                    getSplashImageTransformationMatrix(),
-                    mMetadata.splashScreenFadeOutDurationMillis,
-                    mMetadata.fileProviderAuthority);
+        // When launching asynchronously, developers should check if the Activity is finishing
+        // before calling launchTwa(). We double check the condition here and prevent the launch
+        // if that's the case.
+        if (isFinishing()) {
+            Log.d(TAG, "Aborting launchTwa() as Activity is finishing");
+            return;
         }
 
         CustomTabColorSchemeParams darkModeColorScheme = new CustomTabColorSchemeParams.Builder()

--- a/demos/twa-firebase-analytics/src/main/java/com/google/androidbrowserhelper/demos/twa_firebase_analytics/FirebaseAnalyticsLauncherActivity.java
+++ b/demos/twa-firebase-analytics/src/main/java/com/google/androidbrowserhelper/demos/twa_firebase_analytics/FirebaseAnalyticsLauncherActivity.java
@@ -36,8 +36,7 @@ public class FirebaseAnalyticsLauncherActivity extends LauncherActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // The Activity was finished before the launch because an existing instance of
-        // the app was brought to front. We don't want to call launchTwa() in this case.
+        // `super.onCreate()` may have called `finish()`. In this case, we don't do any work.
         if (isFinishing()) {
             return;
         }

--- a/demos/twa-firebase-analytics/src/main/java/com/google/androidbrowserhelper/demos/twa_firebase_analytics/FirebaseAnalyticsLauncherActivity.java
+++ b/demos/twa-firebase-analytics/src/main/java/com/google/androidbrowserhelper/demos/twa_firebase_analytics/FirebaseAnalyticsLauncherActivity.java
@@ -46,10 +46,10 @@ public class FirebaseAnalyticsLauncherActivity extends LauncherActivity {
 
         // Start the asynchronous task to get the Firebase application instance id.
         firebaseAnalytics.getAppInstanceId().addOnCompleteListener(task -> {
-            // Once the task is complete, save the instance id so it can be used by
-            // getLaunchingUrl().
-            mAppInstanceId = task.getResult();
-            launchTwa();
+                // Once the task is complete, save the instance id so it can be used by
+                // getLaunchingUrl().
+                mAppInstanceId = task.getResult();
+                launchTwa();
         });
     }
 

--- a/demos/twa-firebase-analytics/src/main/java/com/google/androidbrowserhelper/demos/twa_firebase_analytics/FirebaseAnalyticsLauncherActivity.java
+++ b/demos/twa-firebase-analytics/src/main/java/com/google/androidbrowserhelper/demos/twa_firebase_analytics/FirebaseAnalyticsLauncherActivity.java
@@ -36,15 +36,19 @@ public class FirebaseAnalyticsLauncherActivity extends LauncherActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(this);
+        // The Activity was finished before the launch because an existing instance of
+        // the app was brought to front. We don't want to call launchTwa() in this case.
+        if (!isFinishing()) {
+            FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(this);
 
-        // Start the asynchronous task to get the Firebase application instance id.
-        firebaseAnalytics.getAppInstanceId().addOnCompleteListener(task -> {
+            // Start the asynchronous task to get the Firebase application instance id.
+            firebaseAnalytics.getAppInstanceId().addOnCompleteListener(task -> {
                 // Once the task is complete, save the instance id so it can be used by
                 // getLaunchingUrl().
                 mAppInstanceId = task.getResult();
                 launchTwa();
-        });
+            });
+        }
     }
 
     @Override

--- a/demos/twa-firebase-analytics/src/main/java/com/google/androidbrowserhelper/demos/twa_firebase_analytics/FirebaseAnalyticsLauncherActivity.java
+++ b/demos/twa-firebase-analytics/src/main/java/com/google/androidbrowserhelper/demos/twa_firebase_analytics/FirebaseAnalyticsLauncherActivity.java
@@ -38,17 +38,19 @@ public class FirebaseAnalyticsLauncherActivity extends LauncherActivity {
 
         // The Activity was finished before the launch because an existing instance of
         // the app was brought to front. We don't want to call launchTwa() in this case.
-        if (!isFinishing()) {
-            FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(this);
-
-            // Start the asynchronous task to get the Firebase application instance id.
-            firebaseAnalytics.getAppInstanceId().addOnCompleteListener(task -> {
-                // Once the task is complete, save the instance id so it can be used by
-                // getLaunchingUrl().
-                mAppInstanceId = task.getResult();
-                launchTwa();
-            });
+        if (isFinishing()) {
+            return;
         }
+
+        FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(this);
+
+        // Start the asynchronous task to get the Firebase application instance id.
+        firebaseAnalytics.getAppInstanceId().addOnCompleteListener(task -> {
+            // Once the task is complete, save the instance id so it can be used by
+            // getLaunchingUrl().
+            mAppInstanceId = task.getResult();
+            launchTwa();
+        });
     }
 
     @Override

--- a/demos/twa-offline-first/src/main/java/com/google/androidbrowserhelper/demos/twa_offline_first/OfflineFirstTWALauncherActivity.java
+++ b/demos/twa-offline-first/src/main/java/com/google/androidbrowserhelper/demos/twa_offline_first/OfflineFirstTWALauncherActivity.java
@@ -30,6 +30,12 @@ public class OfflineFirstTWALauncherActivity extends LauncherActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // The Activity was finished before the launch because an existing instance of
+        // the app was brought to front. We don't want to call launchTwa() in this case.
+        if (isFinishing()) {
+            return;
+        }
         tryLaunchTwa();
     }
 

--- a/demos/twa-offline-first/src/main/java/com/google/androidbrowserhelper/demos/twa_offline_first/OfflineFirstTWALauncherActivity.java
+++ b/demos/twa-offline-first/src/main/java/com/google/androidbrowserhelper/demos/twa_offline_first/OfflineFirstTWALauncherActivity.java
@@ -31,8 +31,7 @@ public class OfflineFirstTWALauncherActivity extends LauncherActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // The Activity was finished before the launch because an existing instance of
-        // the app was brought to front. We don't want to call launchTwa() in this case.
+        // `super.onCreate()` may have called `finish()`. In this case, we don't do any work.
         if (isFinishing()) {
             return;
         }


### PR DESCRIPTION
- Moved code that builds the splash screen strategy to run on
  `onCreate()`, so they will already be available when
  `onEnterAnimationComplete()` is invoked.
- When `finish()` is called early, on `onCreate()`, to bring an
  existing Activity to front, `launchTwa()` shouldn't be invoked.
- We update the Firebase demo to reflect that and add a guard in
  `launchTwa()`.

Closes #281 