### PR TITLE
[LocationDelegation] Handle only granted approximate location on S+

### DIFF
--- a/locationdelegation/src/main/AndroidManifest.xml
+++ b/locationdelegation/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.google.androidbrowserhelper.locationdelegation">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application>
         <activity android:name=".PermissionRequestActivity"/>

--- a/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderAndroid.java
+++ b/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderAndroid.java
@@ -14,7 +14,9 @@
 
 package com.google.androidbrowserhelper.locationdelegation;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.Criteria;
 import android.location.Location;
 import android.location.LocationListener;
@@ -102,7 +104,11 @@ public class LocationProviderAndroid extends LocationProvider implements Locatio
 
         try {
             Criteria criteria = new Criteria();
-            if (enableHighAccuracy) criteria.setAccuracy(Criteria.ACCURACY_FINE);
+            if (enableHighAccuracy &&
+                    mContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+                            == PackageManager.PERMISSION_GRANTED) {
+                criteria.setAccuracy(Criteria.ACCURACY_FINE);
+            }
             mLocationManager.requestLocationUpdates(0, 0, criteria,
                     this, Looper.getMainLooper());
         } catch (SecurityException e) {

--- a/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderGmsCore.java
+++ b/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderGmsCore.java
@@ -14,7 +14,9 @@
 
 package com.google.androidbrowserhelper.locationdelegation;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.Looper;
@@ -46,7 +48,7 @@ public class LocationProviderGmsCore extends LocationProvider
 
     private static LocationProviderGmsCore sProvider;
     private final GoogleApiClient mGoogleApiClient;
-    private FusedLocationProviderApi mLocationProviderApi = LocationServices.FusedLocationApi;
+    private final FusedLocationProviderApi mLocationProviderApi = LocationServices.FusedLocationApi;
 
     private boolean mEnableHighAccuracy;
     private LocationRequest mLocationRequest;
@@ -68,7 +70,10 @@ public class LocationProviderGmsCore extends LocationProvider
     @Override
     public void onConnected(Bundle connectionHint) {
         mLocationRequest = LocationRequest.create();
-        if (mEnableHighAccuracy) {
+        if (mEnableHighAccuracy
+                && mGoogleApiClient.getContext().checkCallingOrSelfPermission(
+                        Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED) {
             // With enableHighAccuracy, request a faster update interval and configure the provider
             // for high accuracy mode.
             mLocationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY)

--- a/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/PermissionRequestActivity.java
+++ b/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/PermissionRequestActivity.java
@@ -27,6 +27,8 @@ import android.os.Messenger;
 import android.os.RemoteException;
 import android.text.TextUtils;
 
+import java.util.Arrays;
+
 import androidx.browser.trusted.TrustedWebActivityCallbackRemote;
 import androidx.core.app.ActivityCompat;
 
@@ -42,7 +44,8 @@ public class PermissionRequestActivity extends Activity {
     private static final String EXTRA_PERMISSIONS = "EXTRA_PERMISSIONS";
     private static final String EXTRA_GRANT_RESULTS = "EXTRA_GRANTED_RESULT";
 
-    private static final String LOCATION_PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION;
+    private static final String[] LOCATION_PERMISSION =
+            {Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION};
 
     private Messenger mMessenger;
 
@@ -61,7 +64,7 @@ public class PermissionRequestActivity extends Activity {
 
         final Messenger messenger = new Messenger(handler);
         Intent intent = new Intent(context, PermissionRequestActivity.class);
-        intent.putExtra(EXTRA_PERMISSIONS, new String[]{LOCATION_PERMISSION});
+        intent.putExtra(EXTRA_PERMISSIONS, LOCATION_PERMISSION);
         intent.putExtra(EXTRA_RESULT_RECEIVER, messenger);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(intent);
@@ -71,7 +74,7 @@ public class PermissionRequestActivity extends Activity {
             TrustedWebActivityCallbackRemote callback, String[] permissions, int[] grantedResult) {
         Bundle result = new Bundle();
         for (int i = 0; i < permissions.length; i++) {
-            if (TextUtils.equals(permissions[i], LOCATION_PERMISSION)) {
+            if (Arrays.asList(LOCATION_PERMISSION).contains(permissions[i])) {
                 result.putBoolean(LOCATION_PERMISSION_RESULT,
                         grantedResult[i] == PackageManager.PERMISSION_GRANTED);
             }


### PR DESCRIPTION
For simplicity, we always request both fine location and coarse location.
When the location prompt show and users only allow the approximate location, treat it as "Allowed"
