### PR TITLE
[SharedPreferencesTokenStore] Use applicationContext

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/SharedPreferencesTokenStore.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/SharedPreferencesTokenStore.java
@@ -43,7 +43,7 @@ public class SharedPreferencesTokenStore implements TokenStore {
      * @param mContext The {@link Context} where the {@link SharedPreferences} will be stored.
      */
     public SharedPreferencesTokenStore(Context mContext) {
-        this.mContext = mContext;
+        this.mContext = mContext.getApplicationContext();
     }
 
     /**


### PR DESCRIPTION
Context used to build `SharedPreferencesTokenStore` is never freed, thus
leading to a memory leak when activity which calls `TwaLauncher` is
destroy (`SharedPreferencesTokenStore` is build through
`TwaLauncher` constructor). See #312 for more explanation / trace.