### PR TITLE
Only set SubscriptionUpdateParams only if purchaseToken is set

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -117,15 +117,12 @@ public class PlayBillingWrapper implements BillingWrapper {
         BillingFlowParams.Builder builder = BillingFlowParams.newBuilder();
         builder.setSkuDetails(sku);
 
-        if (methodData.purchaseToken != null) {
-            subUpdateParamsBuilder.setOldSkuPurchaseToken(methodData.purchaseToken);
-        }
-
         if (methodData.prorationMode != null) {
             subUpdateParamsBuilder.setReplaceSkusProrationMode(methodData.prorationMode);
         }
 
-        if (methodData.purchaseToken != null || methodData.prorationMode != null) {
+        if (methodData.purchaseToken != null) {
+            subUpdateParamsBuilder.setOldSkuPurchaseToken(methodData.purchaseToken);
             builder.setSubscriptionUpdateParams(subUpdateParamsBuilder.build());
         }
 


### PR DESCRIPTION
According to [this](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.Builder#setReplaceSkusProrationMode(int)), a default proration mode will be set. So instead of calling `setSubscriptionUpdateParams` only if `purchaseToken` and `prorationMode` are both set, we can call it as long as just `purchaseToken` is set.