### PR TITLE
Sets FLAG_IMMUTABLE to the PendingIntent on FocusActivity

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -20,11 +20,11 @@ apply plugin: 'maven-publish'
 def VERSION = "2.2.2";
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName VERSION
 

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/FocusActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/FocusActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
@@ -39,8 +40,12 @@ public class FocusActivity extends Activity {
         // flag.
         focusIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
+        // Setting FLAG_MUTABLE or FLAG_IMMUTABLE is required from API Level 31 and above. However,
+        // the flag is not available below API level 23.
+        int flags =
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0;
         containerIntent.putExtra(EXTRA_FOCUS_INTENT,
-                PendingIntent.getActivity(context, 0, focusIntent, 0));
+                PendingIntent.getActivity(context, 0, focusIntent, flags));
     }
 
     @Override


### PR DESCRIPTION
Starting with API level 31, developers are required to set
FLAG_MUTABLE or FLAG_IMMUTABLE to PendingIntents. This pull
request makes android-browser-helper compatible to API level 31.