### PR TITLE
Split some PurchaseDetails fields into LegacyPurchaseDetails.

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/LegacyPurchaseDetails.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/LegacyPurchaseDetails.java
@@ -1,0 +1,112 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import android.os.Bundle;
+
+import com.android.billingclient.api.Purchase;
+
+/**
+ * An old version of {@link PurchaseDetails} that was used for
+ * {@link DigitalGoodsRequestHandler#DIGITAL_GOODS_API_VERSION} 1. This is kept around so that newer
+ * TWA shells will still work with older versions of Chrome, but will eventually be deleted.
+ */
+public class LegacyPurchaseDetails extends PurchaseDetails {
+    private static final String KEY_ACKNOWLEDGED = "purchaseDetails.acknowledged";
+    private static final String KEY_PURCHASE_STATE = "purchaseDetails.purchaseState";
+    private static final String KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH =
+            "purchaseDetails.purchaseTimeMicrosecondsPastUnixEpoch";
+    private static final String KEY_WILL_AUTO_RENEW = "purchaseDetails.willAutoRenew";
+
+    static final int CHROMIUM_PURCHASE_STATE_UNKNOWN = 0;
+    static final int CHROMIUM_PURCHASE_STATE_PURCHASED = 1;
+    static final int CHROMIUM_PURCHASE_STATE_PENDING = 2;
+
+    /**
+     * This is the id according to Chromium, which corresponds to {@link Purchase#getSku}, not to
+     * {@link Purchase#getOrderId}.DIGITAL_GOODS_API_VERSION
+     */
+    public final boolean acknowledged;
+    public final int purchaseState;
+    public final long purchaseTimeMicrosecondsPastUnixEpoch;
+    public final boolean willAutoRenew;
+
+    private LegacyPurchaseDetails(String id, String purchaseToken, boolean acknowledged,
+            int purchaseState, long purchaseTimeMicrosecondsPastUnixEpoch, boolean willAutoRenew) {
+        super(id, purchaseToken);
+        this.acknowledged = acknowledged;
+        this.purchaseState = purchaseState;
+        this.purchaseTimeMicrosecondsPastUnixEpoch = purchaseTimeMicrosecondsPastUnixEpoch;
+        this.willAutoRenew = willAutoRenew;
+    }
+
+    /**
+     * Creates this class from a Play Billing {@link Purchase}.
+     */
+    public static LegacyPurchaseDetails create(Purchase purchase) {
+        return new LegacyPurchaseDetails(
+                purchase.getSkus().get(0),
+                purchase.getPurchaseToken(),
+                purchase.isAcknowledged(),
+                toChromiumPurchaseState(purchase.getPurchaseState()),
+                millisecondsToMicroseconds(purchase.getPurchaseTime()),
+                purchase.isAutoRenewing()
+        );
+    }
+
+    /**
+     * Creates this class from a {@link Bundle} previously created by {@link #toBundle}.
+     */
+    public static LegacyPurchaseDetails create(Bundle bundle) {
+        String id = bundle.getString(PurchaseDetails.KEY_ITEM_ID);
+        String token = bundle.getString(PurchaseDetails.KEY_PURCHASE_TOKEN);
+        boolean acknowledged = bundle.getBoolean(KEY_ACKNOWLEDGED);
+        int state = bundle.getInt(KEY_PURCHASE_STATE);
+        long timeMsPastUnixEpoch = bundle.getLong(KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH);
+        boolean willAutoRenew = bundle.getBoolean(KEY_WILL_AUTO_RENEW);
+        return new LegacyPurchaseDetails(id, token, acknowledged, state, timeMsPastUnixEpoch,
+                willAutoRenew);
+    }
+
+    /**
+     * Serializes this object to a {@link Bundle} for sending to Chromium.
+     */
+    public Bundle toBundle() {
+        Bundle bundle = super.toBundle();
+
+        bundle.putBoolean(KEY_ACKNOWLEDGED, acknowledged);
+        bundle.putInt(KEY_PURCHASE_STATE, purchaseState);
+        bundle.putLong(KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH,
+                purchaseTimeMicrosecondsPastUnixEpoch);
+        bundle.putBoolean(KEY_WILL_AUTO_RENEW, willAutoRenew);
+
+        return bundle;
+    }
+
+    private static long millisecondsToMicroseconds(long milliseconds) {
+        return milliseconds * 1000;
+    }
+
+    private static int toChromiumPurchaseState(@Purchase.PurchaseState int purchaseState) {
+        switch (purchaseState) {
+            case Purchase.PurchaseState.PENDING:
+                return CHROMIUM_PURCHASE_STATE_PENDING;
+            case Purchase.PurchaseState.PURCHASED:
+                return CHROMIUM_PURCHASE_STATE_PURCHASED;
+            default:
+                return CHROMIUM_PURCHASE_STATE_UNKNOWN;
+        }
+    }
+}

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ListPurchasesCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ListPurchasesCall.java
@@ -74,7 +74,7 @@ public class ListPurchasesCall {
 
             int index = 0;
             for (Purchase purchase : purchaseList) {
-                parcelables[index++] = PurchaseDetails.create(purchase).toBundle();
+                parcelables[index++] = LegacyPurchaseDetails.create(purchase).toBundle();
             }
         }
 

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetails.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/PurchaseDetails.java
@@ -26,17 +26,8 @@ import com.android.billingclient.api.Purchase;
  * https://source.chromium.org/chromium/chromium/src/+/master:chrome/android/java/src/org/chromium/chrome/browser/browserservices/digitalgoods/ListPurchasesConverter.java;drc=a04f522e96fc0eaa0bbcb6eafa96d02aabe5452a
  */
 public class PurchaseDetails {
-    private static final String KEY_ITEM_ID = "purchaseDetails.itemId";
-    private static final String KEY_PURCHASE_TOKEN = "purchaseDetails.purchaseToken";
-    private static final String KEY_ACKNOWLEDGED = "purchaseDetails.acknowledged";
-    private static final String KEY_PURCHASE_STATE = "purchaseDetails.purchaseState";
-    private static final String KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH =
-            "purchaseDetails.purchaseTimeMicrosecondsPastUnixEpoch";
-    private static final String KEY_WILL_AUTO_RENEW = "purchaseDetails.willAutoRenew";
-
-    static final int CHROMIUM_PURCHASE_STATE_UNKNOWN = 0;
-    static final int CHROMIUM_PURCHASE_STATE_PURCHASED = 1;
-    static final int CHROMIUM_PURCHASE_STATE_PENDING = 2;
+    static final String KEY_ITEM_ID = "purchaseDetails.itemId";
+    static final String KEY_PURCHASE_TOKEN = "purchaseDetails.purchaseToken";
 
     /**
      * This is the id according to Chromium, which corresponds to {@link Purchase#getSku}, not to
@@ -44,33 +35,17 @@ public class PurchaseDetails {
      */
     public final String id;
     public final String purchaseToken;
-    public final boolean acknowledged;
-    public final int purchaseState;
-    public final long purchaseTimeMicrosecondsPastUnixEpoch;
-    public final boolean willAutoRenew;
 
-    private PurchaseDetails(String id, String purchaseToken, boolean acknowledged,
-            int purchaseState, long purchaseTimeMicrosecondsPastUnixEpoch, boolean willAutoRenew) {
+    protected PurchaseDetails(String id, String purchaseToken) {
         this.id = id;
         this.purchaseToken = purchaseToken;
-        this.acknowledged = acknowledged;
-        this.purchaseState = purchaseState;
-        this.purchaseTimeMicrosecondsPastUnixEpoch = purchaseTimeMicrosecondsPastUnixEpoch;
-        this.willAutoRenew = willAutoRenew;
     }
 
     /**
      * Creates this class from a Play Billing {@link Purchase}.
      */
     public static PurchaseDetails create(Purchase purchase) {
-        return new PurchaseDetails(
-                purchase.getSkus().get(0),
-                purchase.getPurchaseToken(),
-                purchase.isAcknowledged(),
-                toChromiumPurchaseState(purchase.getPurchaseState()),
-                millisecondsToMicroseconds(purchase.getPurchaseTime()),
-                purchase.isAutoRenewing()
-        );
+        return new PurchaseDetails(purchase.getSkus().get(0), purchase.getPurchaseToken());
     }
 
     /**
@@ -79,12 +54,7 @@ public class PurchaseDetails {
     public static PurchaseDetails create(Bundle bundle) {
         String id = bundle.getString(KEY_ITEM_ID);
         String token = bundle.getString(KEY_PURCHASE_TOKEN);
-        boolean acknowledged = bundle.getBoolean(KEY_ACKNOWLEDGED);
-        int state = bundle.getInt(KEY_PURCHASE_STATE);
-        long timeMsPastUnixEpoch = bundle.getLong(KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH);
-        boolean willAutoRenew = bundle.getBoolean(KEY_WILL_AUTO_RENEW);
-        return new PurchaseDetails(id, token, acknowledged, state, timeMsPastUnixEpoch,
-                willAutoRenew);
+        return new PurchaseDetails(id, token);
     }
 
     /**
@@ -95,27 +65,7 @@ public class PurchaseDetails {
 
         bundle.putString(KEY_ITEM_ID, id);
         bundle.putString(KEY_PURCHASE_TOKEN, purchaseToken);
-        bundle.putBoolean(KEY_ACKNOWLEDGED, acknowledged);
-        bundle.putInt(KEY_PURCHASE_STATE, purchaseState);
-        bundle.putLong(KEY_PURCHASE_TIME_MICROSECONDS_PAST_UNIX_EPOCH,
-                purchaseTimeMicrosecondsPastUnixEpoch);
-        bundle.putBoolean(KEY_WILL_AUTO_RENEW, willAutoRenew);
 
         return bundle;
-    }
-
-    private static long millisecondsToMicroseconds(long milliseconds) {
-        return milliseconds * 1000;
-    }
-
-    private static int toChromiumPurchaseState(@Purchase.PurchaseState int purchaseState) {
-        switch (purchaseState) {
-            case Purchase.PurchaseState.PENDING:
-                return CHROMIUM_PURCHASE_STATE_PENDING;
-            case Purchase.PurchaseState.PURCHASED:
-                return CHROMIUM_PURCHASE_STATE_PURCHASED;
-            default:
-                return CHROMIUM_PURCHASE_STATE_UNKNOWN;
-        }
     }
 }

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/LegacyPurchaseDetailsTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/LegacyPurchaseDetailsTest.java
@@ -27,20 +27,19 @@ import org.robolectric.annotation.internal.DoNotInstrument;
 
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addField;
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addFieldWithoutLeadingComma;
-import static com.google.androidbrowserhelper.playbilling.digitalgoods.JsonUtils.addOptionalField;
-import static com.google.androidbrowserhelper.playbilling.digitalgoods.PurchaseDetails.CHROMIUM_PURCHASE_STATE_PENDING;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.LegacyPurchaseDetails.CHROMIUM_PURCHASE_STATE_PENDING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 @DoNotInstrument
 @Config(sdk = {Build.VERSION_CODES.O_MR1})
-public class PurchaseDetailsTest {
+public class LegacyPurchaseDetailsTest {
     @Test
     public void create() throws JSONException {
         Purchase purchase = new Purchase(createPurchaseJson("id", "token", true,
                 Purchase.PurchaseState.PENDING, 123_000, true), "");
 
-        PurchaseDetails details = PurchaseDetails.create(purchase);
+        LegacyPurchaseDetails details = LegacyPurchaseDetails.create(purchase);
 
         assertPurchaseDetails(details,
                 "id",
@@ -56,8 +55,8 @@ public class PurchaseDetailsTest {
         Purchase purchase = new Purchase(createPurchaseJson("id", "token", true,
                 Purchase.PurchaseState.PENDING, 123_000, true), "");
 
-        PurchaseDetails details =
-                PurchaseDetails.create(PurchaseDetails.create(purchase).toBundle());
+        LegacyPurchaseDetails details =
+                LegacyPurchaseDetails.create(LegacyPurchaseDetails.create(purchase).toBundle());
 
         assertPurchaseDetails(details,
                 "id",
@@ -68,9 +67,9 @@ public class PurchaseDetailsTest {
                 true);
     }
 
-    static void assertPurchaseDetails(PurchaseDetails details, String id, String token,
-            boolean acknowledged, int state, long purchaseTimeMicrosecondsPastUnixEpoch,
-            boolean willAutoRenew) {
+    static void assertPurchaseDetails(LegacyPurchaseDetails details, String id, String token,
+                                      boolean acknowledged, int state, long purchaseTimeMicrosecondsPastUnixEpoch,
+                                      boolean willAutoRenew) {
         assertEquals(details.id, id);
         assertEquals(details.purchaseToken, token);
         assertEquals(details.acknowledged, acknowledged);

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ListPurchasesCallTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ListPurchasesCallTest.java
@@ -31,13 +31,12 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.internal.DoNotInstrument;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.androidbrowserhelper.playbilling.digitalgoods.DigitalGoodsConverter.toChromiumResponseCode;
-import static com.google.androidbrowserhelper.playbilling.digitalgoods.PurchaseDetails.CHROMIUM_PURCHASE_STATE_PENDING;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.LegacyPurchaseDetails.CHROMIUM_PURCHASE_STATE_PENDING;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -49,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 @Config(sdk = {Build.VERSION_CODES.O_MR1})
 public class ListPurchasesCallTest {
     private final static DigitalGoodsCallback EMPTY_CALLBACK = (name, args) -> {};
-    private final static String PURCHASE_DETAILS = PurchaseDetailsTest.createPurchaseJson(
+    private final static String PURCHASE_DETAILS = LegacyPurchaseDetailsTest.createPurchaseJson(
             "id", "token", true, Purchase.PurchaseState.PENDING, 123_000, true);
 
     private final MockBillingWrapper mBillingWrapper = new MockBillingWrapper();
@@ -86,9 +85,9 @@ public class ListPurchasesCallTest {
                     toChromiumResponseCode(BillingClient.BillingResponseCode.OK));
 
             Parcelable[] array = bundle.getParcelableArray(ListPurchasesCall.KEY_PURCHASES_LIST);
-            PurchaseDetails details = PurchaseDetails.create((Bundle) array[0]);
+            LegacyPurchaseDetails details = LegacyPurchaseDetails.create((Bundle) array[0]);
 
-            PurchaseDetailsTest.assertPurchaseDetails(details,
+            LegacyPurchaseDetailsTest.assertPurchaseDetails(details,
                     "id",
                     "token",
                     true,


### PR DESCRIPTION
We'll keep LegacyPurchaseDetails around to work with older versions of Chrome, but we want a the new PurchaseDetails class so that it can be shared by the ListPurchases call and the ListPurchaseHistoryCall.