### PR TITLE
Refactor MockBillingWrapper

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/InvocationTracker.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/InvocationTracker.java
@@ -29,20 +29,24 @@ class InvocationTracker<Argument, Callback> {
     @Nullable private Callback mCallback;
     @Nullable private Argument mArgument;
 
+    /** Pretend that the method was called with the given argument and callback. */
     public void call(Argument argument, Callback callback) {
         mCallback = callback;
         mArgument = argument;
         mCalledLatch.countDown();
     }
 
-    public Argument getArgument() {
+    /** Returns the argument that the method was previously called with, if any. */
+    public @Nullable Argument getArgument() {
         return mArgument;
     }
 
-    public Callback getCallback() {
+    /** Returns the callback that the method was previously called with, if any. */
+    public @Nullable Callback getCallback() {
         return mCallback;
     }
 
+    /** Wait until the method was called, returns {@code false} if the wait timed out. */
     public boolean waitUntilCalled() throws InterruptedException {
         return mCalledLatch.await(5, TimeUnit.SECONDS);
     }

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/InvocationTracker.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/InvocationTracker.java
@@ -1,0 +1,49 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.provider;
+
+import androidx.annotation.Nullable;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A helper class for {@link MockBillingWrapper} that helps keep track of which methods were called
+ * and the arguments they were called with.
+ */
+class InvocationTracker<Argument, Callback> {
+    private final CountDownLatch mCalledLatch = new CountDownLatch(1);
+
+    @Nullable private Callback mCallback;
+    @Nullable private Argument mArgument;
+
+    public void call(Argument argument, Callback callback) {
+        mCallback = callback;
+        mArgument = argument;
+        mCalledLatch.countDown();
+    }
+
+    public Argument getArgument() {
+        return mArgument;
+    }
+
+    public Callback getCallback() {
+        return mCallback;
+    }
+
+    public boolean waitUntilCalled() throws InterruptedException {
+        return mCalledLatch.await(5, TimeUnit.SECONDS);
+    }
+}

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MockBillingWrapper.java
@@ -28,6 +28,7 @@ import com.android.billingclient.api.PurchasesResponseListener;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsResponseListener;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -41,30 +42,25 @@ public class MockBillingWrapper implements BillingWrapper {
 
     private BillingClientStateListener mConnectionStateListener;
 
-    private List<String> mQueriedSkuDetails;
     private boolean mPaymentFlowSuccessful;
-    private SkuDetailsResponseListener mPendingQueryInAppSkuDetailsCallback;
-    private SkuDetailsResponseListener mPendingQuerySubsSkuDetailsCallback;
-    private PurchasesResponseListener mPendingQueryInAppPurchaseDetailsCallback;
-    private PurchasesResponseListener mPendingQuerySubsPurchaseDetailsCallback;
-    private PriceChangeConfirmationListener mPendingPriceChangeConfirmationFlowCallback;
 
-    private String mAcknowledgeToken;
-    private AcknowledgePurchaseResponseListener mPendingAcknowledgeCallback;
+    private InvocationTracker<String, AcknowledgePurchaseResponseListener>
+            mAcknowledgeInvocation = new InvocationTracker<>();
+    private InvocationTracker<String, ConsumeResponseListener>
+            mConsumeInvocation = new InvocationTracker<>();
 
-    private String mConsumeToken;
-    private ConsumeResponseListener mPendingConsumeCallback;
+    private MultiSkuTypeInvocationTracker<List<String>, SkuDetailsResponseListener>
+            mQuerySkuDetailsInvocation = new MultiSkuTypeInvocationTracker<>();
+    private MultiSkuTypeInvocationTracker<Void, PurchasesResponseListener>
+            mQueryPurchasesInvocation = new MultiSkuTypeInvocationTracker<>();
+
+    private InvocationTracker<SkuDetails, PriceChangeConfirmationListener>
+            mPriceChangeConfirmationFlow = new InvocationTracker<>();
 
     private Intent mPlayBillingFlowLaunchIntent;
 
     private final CountDownLatch mConnectLatch = new CountDownLatch(1);
     private final CountDownLatch mLaunchPaymentFlowLatch = new CountDownLatch(1);
-    private final CountDownLatch mLaunchPriceChangeConfirmationFlowLatch = new CountDownLatch(1);
-
-    // These two CountDownLatches are initialized to 2 because they should be called for both in app
-    // and subscription SKU types.
-    private final CountDownLatch mQuerySkuDetailsLatch = new CountDownLatch(2);
-    private final CountDownLatch mQueryPurchasesLatch = new CountDownLatch(2);
 
     @Override
     public void connect(BillingClientStateListener callback) {
@@ -75,35 +71,22 @@ public class MockBillingWrapper implements BillingWrapper {
     @Override
     public void querySkuDetails(@BillingClient.SkuType String skuType, List<String> skus,
             SkuDetailsResponseListener callback) {
-        mQueriedSkuDetails = skus;
-        mQuerySkuDetailsLatch.countDown();
-        if (BillingClient.SkuType.INAPP.equals(skuType)) {
-            mPendingQueryInAppSkuDetailsCallback = callback;
-        } else {
-            mPendingQuerySubsSkuDetailsCallback = callback;
-        }
+        mQuerySkuDetailsInvocation.call(skuType, skus, callback);
     }
 
     @Override
     public void queryPurchases(String skuType, PurchasesResponseListener callback) {
-        mQueryPurchasesLatch.countDown();
-        if (BillingClient.SkuType.INAPP.equals(skuType)) {
-            mPendingQueryInAppPurchaseDetailsCallback = callback;
-        } else {
-            mPendingQuerySubsPurchaseDetailsCallback = callback;
-        }
+        mQueryPurchasesInvocation.call(skuType, null, callback);
     }
 
     @Override
     public void acknowledge(String token, AcknowledgePurchaseResponseListener callback) {
-        mAcknowledgeToken = token;
-        mPendingAcknowledgeCallback = callback;
+        mAcknowledgeInvocation.call(token, callback);
     }
 
     @Override
     public void consume(String token, ConsumeResponseListener callback) {
-        mConsumeToken = token;
-        mPendingConsumeCallback = callback;
+        mConsumeInvocation.call(token, callback);
     }
 
     @Override
@@ -116,8 +99,7 @@ public class MockBillingWrapper implements BillingWrapper {
     @Override
     public void launchPriceChangeConfirmationFlow(Activity activity, SkuDetails sku,
             PriceChangeConfirmationListener listener) {
-        mLaunchPriceChangeConfirmationFlowLatch.countDown();
-        mPendingPriceChangeConfirmationFlowCallback = listener;
+        mPriceChangeConfirmationFlow.call(sku, listener);
     }
 
     public void triggerConnected() {
@@ -139,7 +121,8 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     public void triggerOnGotInAppSkuDetails(int responseCode, List<SkuDetails> skuDetails) {
-        mPendingQueryInAppSkuDetailsCallback.onSkuDetailsResponse(toResult(responseCode), skuDetails);
+        mQuerySkuDetailsInvocation.getCallback(BillingClient.SkuType.INAPP)
+                .onSkuDetailsResponse(toResult(responseCode), skuDetails);
     }
 
     public void triggerOnGotSubsSkuDetails(List<SkuDetails> skuDetails) {
@@ -147,25 +130,26 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     public void triggerOnGotSubsSkuDetails(int responseCode, List<SkuDetails> skuDetails) {
-        mPendingQuerySubsSkuDetailsCallback.onSkuDetailsResponse(toResult(responseCode), skuDetails);
+        mQuerySkuDetailsInvocation.getCallback(BillingClient.SkuType.SUBS)
+                .onSkuDetailsResponse(toResult(responseCode), skuDetails);
     }
 
     public void triggerOnGotInAppPurchaseDetails(List<Purchase> details) {
-        mPendingQueryInAppPurchaseDetailsCallback.onQueryPurchasesResponse(
-                toResult(BillingClient.BillingResponseCode.OK), details);
+        mQueryPurchasesInvocation.getCallback(BillingClient.SkuType.INAPP)
+                .onQueryPurchasesResponse(toResult(BillingClient.BillingResponseCode.OK), details);
     }
 
     public void triggerOnGotSubsPurchaseDetails(List<Purchase> details) {
-        mPendingQuerySubsPurchaseDetailsCallback.onQueryPurchasesResponse(
-                toResult(BillingClient.BillingResponseCode.OK), details);
+        mQueryPurchasesInvocation.getCallback(BillingClient.SkuType.SUBS)
+                .onQueryPurchasesResponse(toResult(BillingClient.BillingResponseCode.OK), details);
     }
 
     public void triggerAcknowledge(int responseCode) {
-        mPendingAcknowledgeCallback.onAcknowledgePurchaseResponse(toResult(responseCode));
+        mAcknowledgeInvocation.getCallback().onAcknowledgePurchaseResponse(toResult(responseCode));
     }
 
     public void triggerConsume(int responseCode, String token) {
-        mPendingConsumeCallback.onConsumeResponse(toResult(responseCode), token);
+        mConsumeInvocation.getCallback().onConsumeResponse(toResult(responseCode), token);
     }
 
     public void triggerOnPurchasesUpdated() {
@@ -173,7 +157,7 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     public void triggerOnPriceChangeConfirmationResult() {
-        mPendingPriceChangeConfirmationFlowCallback.onPriceChangeConfirmationResult(
+        mPriceChangeConfirmationFlow.getCallback().onPriceChangeConfirmationResult(
                 toResult(BillingClient.BillingResponseCode.OK));
     }
 
@@ -182,7 +166,7 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     public boolean waitForQuerySkuDetails() throws InterruptedException {
-        return wait(mQuerySkuDetailsLatch);
+        return mQuerySkuDetailsInvocation.waitUntilCalled();
     }
 
     public boolean waitForLaunchPaymentFlow() throws InterruptedException {
@@ -190,11 +174,11 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     public boolean waitForLaunchPriceChangeConfirmationFlow() throws InterruptedException {
-        return wait(mLaunchPriceChangeConfirmationFlowLatch);
+        return mPriceChangeConfirmationFlow.waitUntilCalled();
     }
 
     public boolean waitForQueryPurchases() throws InterruptedException {
-        return wait(mQueryPurchasesLatch);
+        return mQueryPurchasesInvocation.waitUntilCalled();
     }
 
     public void setListener(Listener listener) {
@@ -206,15 +190,25 @@ public class MockBillingWrapper implements BillingWrapper {
     }
 
     public List<String> getQueriedSkuDetails() {
-        return mQueriedSkuDetails;
+        List<String> skuDetails = new ArrayList<>();
+
+        List<String> inapp = mQuerySkuDetailsInvocation.getArgument(BillingClient.SkuType.INAPP);
+        List<String> subs = mQuerySkuDetailsInvocation.getArgument(BillingClient.SkuType.SUBS);
+
+        if (inapp == null && subs == null) return null;
+
+        if (inapp != null) skuDetails.addAll(inapp);
+        if (subs != null) skuDetails.addAll(subs);
+
+        return skuDetails;
     }
 
     public String getConsumeToken() {
-        return mConsumeToken;
+        return mConsumeInvocation.getArgument();
     }
 
     public String getAcknowledgeToken() {
-        return mAcknowledgeToken;
+        return mAcknowledgeInvocation.getArgument();
     }
 
     public Intent getPlayBillingFlowLaunchIntent() {

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MultiSkuTypeInvocationTracker.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MultiSkuTypeInvocationTracker.java
@@ -1,0 +1,49 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.provider;
+
+import com.android.billingclient.api.BillingClient;
+
+/**
+ * A helper class for {@link MockBillingWrapper} that helps keep track of which methods were called
+ * and the arguments they were called with. This class keeps track of two calls - one for the inapp
+ * SkuType and one for the subs SkuType.
+ */
+public class MultiSkuTypeInvocationTracker<Argument, Callback> {
+    private final InvocationTracker<Argument, Callback> mInAppInvocation =
+            new InvocationTracker<>();
+    private final InvocationTracker<Argument, Callback> mSubsInvocation = new InvocationTracker<>();
+
+    private InvocationTracker<Argument, Callback>
+            getTracker(@BillingClient.SkuType String skuType) {
+        return BillingClient.SkuType.INAPP.equals(skuType) ? mInAppInvocation : mSubsInvocation;
+    }
+
+    public void call(@BillingClient.SkuType String skuType, Argument arg, Callback callback) {
+        getTracker(skuType).call(arg, callback);
+    }
+
+    public Argument getArgument(@BillingClient.SkuType String skuType) {
+        return getTracker(skuType).getArgument();
+    }
+
+    public Callback getCallback(@BillingClient.SkuType String skuType) {
+        return getTracker(skuType).getCallback();
+    }
+
+    public boolean waitUntilCalled() throws InterruptedException {
+        return mInAppInvocation.waitUntilCalled() && mSubsInvocation.waitUntilCalled();
+    }
+}

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MultiSkuTypeInvocationTracker.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MultiSkuTypeInvocationTracker.java
@@ -21,7 +21,7 @@ import com.android.billingclient.api.BillingClient;
  * and the arguments they were called with. This class keeps track of two calls - one for the inapp
  * SkuType and one for the subs SkuType.
  */
-public class MultiSkuTypeInvocationTracker<Argument, Callback> {
+class MultiSkuTypeInvocationTracker<Argument, Callback> {
     private final InvocationTracker<Argument, Callback> mInAppInvocation =
             new InvocationTracker<>();
     private final InvocationTracker<Argument, Callback> mSubsInvocation = new InvocationTracker<>();
@@ -31,18 +31,22 @@ public class MultiSkuTypeInvocationTracker<Argument, Callback> {
         return BillingClient.SkuType.INAPP.equals(skuType) ? mInAppInvocation : mSubsInvocation;
     }
 
+    /** Pretend that the method was called with the given SKU type, argument and callback. */
     public void call(@BillingClient.SkuType String skuType, Argument arg, Callback callback) {
         getTracker(skuType).call(arg, callback);
     }
 
+    /** Returns the argument that the method was previously called with, if any. */
     public Argument getArgument(@BillingClient.SkuType String skuType) {
         return getTracker(skuType).getArgument();
     }
 
+    /** Returns the callback that the method was previously called with, if any. */
     public Callback getCallback(@BillingClient.SkuType String skuType) {
         return getTracker(skuType).getCallback();
     }
 
+    /** Wait until the method was called, returns {@code false} if the wait timed out. */
     public boolean waitUntilCalled() throws InterruptedException {
         return mInAppInvocation.waitUntilCalled() && mSubsInvocation.waitUntilCalled();
     }


### PR DESCRIPTION
This change adds the `InvocationTracker` class to hold the logic in MockBillingWrapper that was duplicated across many of the methods it implemented.