### PR TITLE
Implement Consume

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/AcknowledgeCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/AcknowledgeCall.java
@@ -26,6 +26,8 @@ import static com.google.androidbrowserhelper.playbilling.digitalgoods.DigitalGo
 /**
  * A class for parsing Digital Goods API calls from the browser and converting them into a format
  * suitable for calling the Play Billing library.
+ *
+ * This class is kept around for legacy reasons, Consume should be used by clients on DGAPI v2.1.
  */
 public class AcknowledgeCall {
     public static final String COMMAND_NAME = "acknowledge";

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConsumeCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConsumeCall.java
@@ -24,8 +24,6 @@ import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
 /**
  * A class for parsing Digital Goods API calls from the browser and converting them into a format
  * suitable for calling the Play Billing library.
- *
- * This class is kept around for legacy reasons, Consume should be used by clients on DGAPI v2.1.
  */
 public class ConsumeCall {
     public static final String COMMAND_NAME = "consume";

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConsumeCall.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConsumeCall.java
@@ -1,0 +1,81 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+
+import com.android.billingclient.api.BillingResult;
+import com.google.androidbrowserhelper.playbilling.provider.BillingWrapper;
+
+/**
+ * A class for parsing Digital Goods API calls from the browser and converting them into a format
+ * suitable for calling the Play Billing library.
+ *
+ * This class is kept around for legacy reasons, Consume should be used by clients on DGAPI v2.1.
+ */
+public class ConsumeCall {
+    public static final String COMMAND_NAME = "consume";
+
+    public static final String PARAM_CONSUME_PURCHASE_TOKEN = "consume.purchaseToken";
+    public static final String RESPONSE_CONSUME = "consume.response";
+    public static final String RESPONSE_CONSUME_RESPONSE_CODE = "consume.responseCode";
+
+    public final String purchaseToken;
+    private final DigitalGoodsCallback mCallback;
+
+    public ConsumeCall(String purchaseToken, DigitalGoodsCallback callback) {
+        this.purchaseToken = purchaseToken;
+        this.mCallback = callback;
+    }
+
+    /** Creates this class from a {@link Bundle}, returns {@code null} if the Bundle is invalid. **/
+    @Nullable
+    public static ConsumeCall create(@Nullable Bundle args,
+                                     @Nullable DigitalGoodsCallback callback) {
+        if (args == null || callback == null) return null;
+
+        if (!args.containsKey(PARAM_CONSUME_PURCHASE_TOKEN)) return null;
+
+        String token = args.getString(PARAM_CONSUME_PURCHASE_TOKEN);
+
+        return new ConsumeCall(token, callback);
+    }
+
+    /** Calls the callback provided in the constructor with serialized forms of the parameters. */
+    private void respond(BillingResult result) {
+        Logging.logConsumeResponse(result);
+
+        Bundle args = new Bundle();
+        args.putInt(RESPONSE_CONSUME_RESPONSE_CODE,
+                DigitalGoodsConverter.toChromiumResponseCode(result));
+        mCallback.run(RESPONSE_CONSUME, args);
+    }
+
+    /** Calls the appropriate method on {@link BillingWrapper}. */
+    public void call(BillingWrapper billing) {
+        Logging.logConsumeCall(purchaseToken);
+
+        billing.consume(purchaseToken, (result, token) -> respond(result));
+    }
+
+    /** Creates a bundle that can be used with {@link #create}. For testing. */
+    static Bundle createBundleForTesting(String token) {
+        Bundle bundle = new Bundle();
+        bundle.putString(PARAM_CONSUME_PURCHASE_TOKEN, token);
+        return bundle;
+    }
+}

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/DigitalGoodsRequestHandler.java
@@ -81,6 +81,11 @@ public class DigitalGoodsRequestHandler implements ExtraCommandHandler {
                 if (acknowledgeCall == null) break;
                 acknowledgeCall.call(mWrapper);
                 return true;
+            case ConsumeCall.COMMAND_NAME:
+                ConsumeCall consumeCall = ConsumeCall.create(args, callback);
+                if (consumeCall == null) break;
+                consumeCall.call(mWrapper);
+                return true;
             case ListPurchasesCall.COMMAND_NAME:
                 ListPurchasesCall listPurchasesCall = ListPurchasesCall.create(callback);
                 if (listPurchasesCall == null) break;

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/Logging.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/digitalgoods/Logging.java
@@ -44,6 +44,14 @@ public class Logging {
         logResult(result, command + " returned:");
     }
 
+    static void logConsumeCall(String token) {
+        Log.d(TAG, "Calling consume (v2.1) " + token);
+    }
+
+    static void logConsumeResponse(BillingResult result) {
+        logResult(result, "Consume (v2.1) returned:");
+    }
+
     static void logGetDetailsCall(List<String> ids) {
         StringBuilder sb = new StringBuilder();
         boolean first = true;

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConsumeCallTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/digitalgoods/ConsumeCallTest.java
@@ -1,0 +1,75 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.playbilling.digitalgoods;
+
+import android.os.Build;
+import android.os.Bundle;
+
+import com.android.billingclient.api.BillingClient;
+import com.google.androidbrowserhelper.playbilling.provider.BillingWrapperFactory;
+import com.google.androidbrowserhelper.playbilling.provider.MockBillingWrapper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.internal.DoNotInstrument;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.ConsumeCall.RESPONSE_CONSUME;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.ConsumeCall.RESPONSE_CONSUME_RESPONSE_CODE;
+import static com.google.androidbrowserhelper.playbilling.digitalgoods.DigitalGoodsConverter.toChromiumResponseCode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link ConsumeCall} and {@link DigitalGoodsRequestHandler}. */
+@RunWith(RobolectricTestRunner.class)
+@DoNotInstrument
+@Config(sdk = {Build.VERSION_CODES.O_MR1})
+public class ConsumeCallTest {
+    private final MockBillingWrapper mBillingWrapper = new MockBillingWrapper();
+    private DigitalGoodsRequestHandler mHandler;
+
+    @Before
+    public void setUp() {
+        BillingWrapperFactory.setBillingWrapperForTesting(mBillingWrapper);
+        mHandler = new DigitalGoodsRequestHandler(null);
+    }
+
+    @Test
+    public void callsConsume() throws InterruptedException {
+        Bundle args = ConsumeCall.createBundleForTesting("id1");
+        CountDownLatch callbackTriggered = new CountDownLatch(1);
+        int billingResponseCode = BillingClient.BillingResponseCode.ITEM_NOT_OWNED;
+        int chromiumResponseCode = toChromiumResponseCode(billingResponseCode);
+
+        DigitalGoodsCallback callback = (name, bundle) -> {
+            assertEquals(RESPONSE_CONSUME, name);
+            assertEquals(chromiumResponseCode, bundle.getInt(RESPONSE_CONSUME_RESPONSE_CODE));
+            callbackTriggered.countDown();
+        };
+
+        assertTrue(mHandler.handle(ConsumeCall.COMMAND_NAME, args, callback));
+        mBillingWrapper.triggerConnected();
+
+        assertEquals("id1", mBillingWrapper.getConsumeToken());
+        mBillingWrapper.triggerConsume(billingResponseCode, "?");
+
+        assertTrue(callbackTriggered.await(5, TimeUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
This change implements the Consume call, adding it alongside the Acknowledge call which is kept around for backwards compatibility.

Part of issue #355 .