### PR TITLE
Catch exceptions thrown by newSession call.

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -321,11 +321,17 @@ public class TwaLauncher {
                     .supportsLaunchWithoutWarmup(mContext.getPackageManager(), mProviderPackage)) {
                 client.warmup(0);
             }
-            mSession = client.newSession(mCustomTabsCallback, mSessionId);
 
-            if (mSession != null && mOnSessionCreatedRunnable != null) {
-                mOnSessionCreatedRunnable.run();
-            } else if (mSession == null && mOnSessionCreationFailedRunnable != null) {
+            try {
+                mSession = client.newSession(mCustomTabsCallback, mSessionId);
+
+                if (mSession != null && mOnSessionCreatedRunnable != null) {
+                    mOnSessionCreatedRunnable.run();
+                } else if (mSession == null && mOnSessionCreationFailedRunnable != null) {
+                    mOnSessionCreationFailedRunnable.run();
+                }
+            } catch (RuntimeException e) {
+                Log.w(TAG, e);
                 mOnSessionCreationFailedRunnable.run();
             }
 


### PR DESCRIPTION
In Issue #94 , one of the causes is from a browser throwing while in newSession. This PR protects against that and falls back to the Custom Tab launch.