### PR TITLE
Make LocationProviderGmsCore use FusedLocationProviderClient

### DIFF
--- a/locationdelegation/build.gradle
+++ b/locationdelegation/build.gradle
@@ -53,11 +53,11 @@ dependencies {
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'com.google.android.gms:play-services-location:17.0.0'
-    implementation 'androidx.test:core:1.4.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.0.0'
     testImplementation 'org.robolectric:robolectric:4.4'
+    testImplementation 'androidx.test:core:1.4.0'
 
     debugImplementation project(path: ':androidbrowserhelper')
     releaseImplementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.2.2'

--- a/locationdelegation/build.gradle
+++ b/locationdelegation/build.gradle
@@ -41,6 +41,11 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -48,6 +53,11 @@ dependencies {
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'com.google.android.gms:play-services-location:17.0.0'
+    implementation 'androidx.test:core:1.4.0'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:3.0.0'
+    testImplementation 'org.robolectric:robolectric:4.4'
 
     debugImplementation project(path: ':androidbrowserhelper')
     releaseImplementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.2.2'

--- a/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/LocationDelegationExtraCommandHandler.java
+++ b/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/LocationDelegationExtraCommandHandler.java
@@ -35,7 +35,9 @@ public class LocationDelegationExtraCommandHandler implements ExtraCommandHandle
             @Nullable TrustedWebActivityCallbackRemote callback) {
         TrustedWebActivityLocationCallback wrappedCallback = (callbackName, callbackArgs) -> {
             try {
-                callback.runExtraCallback(callbackName, callbackArgs);
+                if (callback != null) {
+                    callback.runExtraCallback(callbackName, callbackArgs);
+                }
             } catch (RemoteException e) {
                 // The remote app crashed/got shut down. Stop location provider.
                 stopLocationProvider(context);
@@ -46,10 +48,12 @@ public class LocationDelegationExtraCommandHandler implements ExtraCommandHandle
         result.putBoolean(EXTRA_COMMAND_SUCCESS, false);
         switch (commandName) {
             case CHECK_LOCATION_PERMISSION_COMMAND_NAME:
+                if (callback == null) break;
                 requestPermission(context, callback);
                 result.putBoolean(EXTRA_COMMAND_SUCCESS, true);
                 break;
             case START_LOCATION_COMMAND_NAME:
+                if (callback == null) break;
                 startLocationProvider(context, wrappedCallback, args.getBoolean("enableHighAccuracy"));
 
                 result.putBoolean(EXTRA_COMMAND_SUCCESS, true);

--- a/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderAndroid.java
+++ b/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderAndroid.java
@@ -27,8 +27,6 @@ import android.util.Log;
 
 import java.util.List;
 
-import androidx.browser.trusted.TrustedWebActivityCallbackRemote;
-
 /**
  * This is a LocationProvider using Android APIs [1]. It is a separate class for clarity so that it
  * can manage all processing completely on the UI thread. The container class ensures that the
@@ -47,7 +45,7 @@ public class LocationProviderAndroid extends LocationProvider implements Locatio
     }
 
     @Override
-    void start(TrustedWebActivityCallbackRemote callback, boolean enableHighAccuracy) {
+    void start(TrustedWebActivityLocationCallback callback, boolean enableHighAccuracy) {
         unregisterFromLocationUpdates();
         mCallback = callback;
         registerForLocationUpdates(enableHighAccuracy);

--- a/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/TrustedWebActivityLocationCallback.java
+++ b/locationdelegation/src/main/java/com/google/androidbrowserhelper/locationdelegation/TrustedWebActivityLocationCallback.java
@@ -1,0 +1,25 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.androidbrowserhelper.locationdelegation;
+
+import android.os.Bundle;
+
+/**
+ * A wrapper for {@link androidx.browser.trusted.TrustedWebActivityCallbackRemote} that we can
+ * construct and use for testing.
+ */
+public interface TrustedWebActivityLocationCallback {
+    /** Runs the callback with the given name and args. **/
+    void run(String callbackName, Bundle args);
+}

--- a/locationdelegation/src/test/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderGmsCoreTest.java
+++ b/locationdelegation/src/test/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderGmsCoreTest.java
@@ -49,15 +49,10 @@ import java.util.concurrent.TimeUnit;
 
 import androidx.test.core.app.ApplicationProvider;
 
-
-import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.location.FusedLocationProviderClient;
-import com.google.android.gms.location.LocationAvailability;
 import com.google.android.gms.location.LocationCallback;
-import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
-import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.common.collect.ImmutableList;
 
@@ -69,8 +64,8 @@ import com.google.common.collect.ImmutableList;
 public class LocationProviderGmsCoreTest {
     private LocationProviderGmsCore mLocationProvider;
 
-    FusedLocationProviderClient mMockLocationClient;
-    LocationCallback mPendingCallback;
+    private FusedLocationProviderClient mMockLocationClient;
+    private LocationCallback mPendingCallback;
 
     @Before
     public void setUp() throws Exception {

--- a/locationdelegation/src/test/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderGmsCoreTest.java
+++ b/locationdelegation/src/test/java/com/google/androidbrowserhelper/locationdelegation/LocationProviderGmsCoreTest.java
@@ -1,0 +1,198 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.androidbrowserhelper.locationdelegation;
+
+import static com.google.androidbrowserhelper.locationdelegation.LocationProvider.EXTRA_NEW_LOCATION_AVAILABLE_CALLBACK;
+import static com.google.androidbrowserhelper.locationdelegation.LocationProvider.EXTRA_NEW_ERROR_AVAILABLE_CALLBACK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.location.Location;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
+import org.robolectric.annotation.internal.DoNotInstrument;
+
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import androidx.test.core.app.ApplicationProvider;
+
+
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationAvailability;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationListener;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.common.collect.ImmutableList;
+
+/** Tests for {@link LocationProviderGmsCore}. */
+@RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
+@DoNotInstrument
+@Config(sdk = {Build.VERSION_CODES.O_MR1})
+public class LocationProviderGmsCoreTest {
+    private LocationProviderGmsCore mLocationProvider;
+
+    FusedLocationProviderClient mMockLocationClient;
+    LocationCallback mPendingCallback;
+
+    @Before
+    public void setUp() throws Exception {
+        Context context = ApplicationProvider.getApplicationContext();
+        mMockLocationClient = spy(LocationServices.getFusedLocationProviderClient(context));
+
+        doAnswer(
+                invocation -> {
+                    mPendingCallback = invocation.getArgument(/* index= */ 1);
+                    return Tasks.forResult(null);
+                })
+                .when(mMockLocationClient)
+                .requestLocationUpdates(
+                        any(), any(LocationCallback.class), any());
+        doAnswer(
+                invocation -> {
+                    mPendingCallback = null;
+                    return Tasks.forResult(null);
+                })
+                .when(mMockLocationClient)
+                .removeLocationUpdates(any(LocationCallback.class));
+        setLastLocation(null);
+
+        mLocationProvider = new LocationProviderGmsCore(context, mMockLocationClient);
+    }
+
+    private Location createMockLocation() {
+        Location location = new Location("mock");
+        location.setLatitude(45.6);
+        location.setLongitude(-128.4);
+        return location;
+    }
+
+    private void createLocationUpdates() {
+        LocationResult result = LocationResult.create(ImmutableList.of(createMockLocation()));
+        if (mPendingCallback != null) {
+            mPendingCallback.onLocationResult(result);
+        }
+    }
+
+    private void setLastLocation(Location lastLocation) {
+        when(mMockLocationClient.getLastLocation()).thenReturn(Tasks.forResult(lastLocation));
+    }
+
+    @Test
+    public void testGetLocationUpdates() throws Exception {
+        CountDownLatch callbackTriggered = new CountDownLatch(1);
+        TrustedWebActivityLocationCallback locationCallback = (callbackName, args) -> {
+            assertEquals(callbackName, EXTRA_NEW_LOCATION_AVAILABLE_CALLBACK);
+            callbackTriggered.countDown();
+            mLocationProvider.stop();
+        };
+
+        mLocationProvider.start(locationCallback, false);
+        createLocationUpdates();
+
+        assertTrue(callbackTriggered.await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testGetsLastLocationFromProvider() throws Exception {
+        CountDownLatch callbackTriggered = new CountDownLatch(1);
+        TrustedWebActivityLocationCallback locationCallback = (callbackName, args) -> {
+            assertEquals(callbackName, EXTRA_NEW_LOCATION_AVAILABLE_CALLBACK);
+            callbackTriggered.countDown();
+            mLocationProvider.stop();
+        };
+
+        setLastLocation(createMockLocation());
+        mLocationProvider.start(locationCallback, false);
+
+        assertTrue(callbackTriggered.await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testMultipleUpdates() throws Exception {
+        CountDownLatch callbackTriggered = new CountDownLatch(3);
+        TrustedWebActivityLocationCallback locationCallback = (callbackName, args) -> {
+            assertEquals(callbackName, EXTRA_NEW_LOCATION_AVAILABLE_CALLBACK);
+            callbackTriggered.countDown();
+        };
+
+        setLastLocation(createMockLocation());
+        mLocationProvider.start(locationCallback, false);
+        createLocationUpdates();
+        createLocationUpdates();
+
+        assertTrue(mLocationProvider.isRunning());
+        assertTrue(callbackTriggered.await(1, TimeUnit.SECONDS));
+
+        mLocationProvider.stop();
+        assertFalse(mLocationProvider.isRunning());
+    }
+
+    @Test
+    public void testStopLocationUpdates() throws Exception {
+        TrustedWebActivityLocationCallback locationCallback =
+                Mockito.mock(TrustedWebActivityLocationCallback.class);
+
+        mLocationProvider.start(locationCallback, false);
+        mLocationProvider.stop();
+        assertFalse(mLocationProvider.isRunning());
+
+        createLocationUpdates();
+        verify(locationCallback, never()).run(any(), any());
+    }
+
+    @Test
+    public void testStopAndReturnWhenError() throws Exception {
+        CountDownLatch callbackTriggered = new CountDownLatch(1);
+        TrustedWebActivityLocationCallback locationCallback = (callbackName, args) -> {
+            assertEquals(callbackName, EXTRA_NEW_ERROR_AVAILABLE_CALLBACK);
+            callbackTriggered.countDown();
+        };
+        doThrow(new IllegalStateException())
+                .when(mMockLocationClient).requestLocationUpdates(any(), any(),any());
+
+        mLocationProvider.start(locationCallback, false);
+
+        assertTrue(callbackTriggered.await(1, TimeUnit.SECONDS));
+        assertFalse(mLocationProvider.isRunning());
+    }
+}
+
+


### PR DESCRIPTION
FusedLocationProviderApi and GoogleApiClient was deprecated,
migrate the usage to the new FusedLocationProviderClient.
See https://android-developers.googleblog.com/2017/11/moving-past-googleapiclient_21.html

Also add tests for LocationProviderGmsCore.