### PR TITLE
Pull CustomTabsCallback to a getter from private field

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -115,8 +115,6 @@ public class LauncherActivity extends Activity {
     @Nullable
     private PwaWrapperSplashScreenStrategy mSplashScreenStrategy;
 
-    private CustomTabsCallback mCustomTabsCallback = new QualityEnforcer();
-
     @Nullable
     private TwaLauncher mTwaLauncher;
 
@@ -222,7 +220,7 @@ public class LauncherActivity extends Activity {
 
         mTwaLauncher = createTwaLauncher();
         mTwaLauncher.launch(twaBuilder,
-                mCustomTabsCallback,
+                getCustomTabsCallback(),
                 mSplashScreenStrategy,
                 () -> mBrowserWasLaunched = true,
                 getFallbackStrategy());
@@ -242,6 +240,10 @@ public class LauncherActivity extends Activity {
 
         ManageDataLauncherActivity.addSiteSettingsShortcut(this,
                 mTwaLauncher.getProviderPackage());
+    }
+
+    protected CustomTabsCallback getCustomTabsCallback() {
+        return new QualityEnforcer();
     }
 
     protected TwaLauncher createTwaLauncher() {


### PR DESCRIPTION
TWA based apps might want to listen to CCT call back events and take appropriate action ( eg. capture metrics about usage). Since the field currently is private and used in launchTWA() its not possible for the extending classes to change the behavior. This change pulls out the private field and creates a overridable method that supplies the Callback