### PR TITLE
Allows media playback without user interaction on WebViewFallback

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/WebViewFallbackActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/WebViewFallbackActivity.java
@@ -322,5 +322,8 @@ public class WebViewFallbackActivity extends Activity {
         webSettings.setJavaScriptEnabled(true);
         webSettings.setDomStorageEnabled(true);
         webSettings.setDatabaseEnabled(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            webSettings.setMediaPlaybackRequiresUserGesture(false);
+        }
     }
 }


### PR DESCRIPTION
Sets `webSettings.setMediaPlaybackRequiresUserGesture(false)`. This should be fine to set as default, as we want to mimic the behaviour a platform-specific app would have and play media by default.

See #413