### PR TITLE
Update a comment in PostMessage demo

### DIFF
--- a/demos/twa-post-message/src/main/java/com/google/androidbrowserhelper/demos/twapostmessage/MainActivity.java
+++ b/demos/twa-post-message/src/main/java/com/google/androidbrowserhelper/demos/twapostmessage/MainActivity.java
@@ -56,8 +56,8 @@ public class MainActivity extends AppCompatActivity {
     private CustomTabsSession mSession;
     private Uri URL = Uri.parse("https://peconn.github.io/starters");
 
-    // This can be the app's package name.
-    private Uri SOURCE_ORIGIN = Uri.parse("my-app-origin-uri");
+    // This can be the app's package name, it has to either start with http or https.
+    private Uri SOURCE_ORIGIN = Uri.parse("https://my-app-origin-uri");
     private Uri TARGET_ORIGIN = Uri.parse("https://peconn.github.io");
     private boolean mValidated = false;
 


### PR DESCRIPTION
SOURCE_ORIGIN gets checked to be a valid origin and that wasn't clear from the comment, right now the browserservices.Origin only supports HTTTP and HTTPS. 