### PR TITLE
Update the flag when querying the Activities which can handle VIEW intent

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -20,11 +20,11 @@ apply plugin: 'maven-publish'
 def VERSION = "2.5.0";
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName VERSION
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.2.1'
     }
 }
 

--- a/demos/custom-tabs-example-app/build.gradle
+++ b/demos/custom-tabs-example-app/build.gradle
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         applicationId "org.chromium.customtabsdemos"
         minSdkVersion 26
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }

--- a/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomTabsHelper.java
+++ b/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomTabsHelper.java
@@ -73,7 +73,7 @@ public class CustomTabsHelper {
         }
 
         // Get all apps that can handle VIEW intents.
-        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL);
         List<String> packagesSupportingCustomTabs = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {
             Intent serviceIntent = new Intent();

--- a/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomTabsHelper.java
+++ b/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomTabsHelper.java
@@ -74,6 +74,9 @@ public class CustomTabsHelper {
         }
 
         // Get all apps that can handle VIEW intents.
+        // NB: It will return only the default browser instead of all the apps which can handle
+        // Intent.ACTION_VIEW on OnePlus Pro (Android 12). Updating the flag from 0 to MATCH_ALL
+        // fixed this.
         List<ResolveInfo> resolvedActivityList;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.ResolveInfoFlags.of(

--- a/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomTabsHelper.java
+++ b/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomTabsHelper.java
@@ -75,8 +75,8 @@ public class CustomTabsHelper {
 
         // Get all apps that can handle VIEW intents.
         // NB: It will return only the default browser instead of all the apps which can handle
-        // Intent.ACTION_VIEW on OnePlus Pro (Android 12). Updating the flag from 0 to MATCH_ALL
-        // fixed this.
+        // Intent.ACTION_VIEW on OnePlus7 Pro (Android 12). Updating the flag from 0 to MATCH_ALL
+        // fixed this issue.
         List<ResolveInfo> resolvedActivityList;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.ResolveInfoFlags.of(

--- a/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomTabsHelper.java
+++ b/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/CustomTabsHelper.java
@@ -20,6 +20,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -73,7 +74,13 @@ public class CustomTabsHelper {
         }
 
         // Get all apps that can handle VIEW intents.
-        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL);
+        List<ResolveInfo> resolvedActivityList;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.ResolveInfoFlags.of(
+                    PackageManager.MATCH_ALL));
+        } else {
+            resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL);
+        }
         List<String> packagesSupportingCustomTabs = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {
             Intent serviceIntent = new Intent();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
Update the query flag to cover more installed browser apps (besides Chrome) which may support custom tabs.