### PR TITLE
Move connecting/disconnecting from service to onCreate/Destroy

### DIFF
--- a/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/ServiceConnectionActivity.java
+++ b/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/ServiceConnectionActivity.java
@@ -15,6 +15,7 @@ package org.chromium.customtabsdemos;
 
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 
@@ -36,21 +37,23 @@ public class ServiceConnectionActivity extends AppCompatActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_serviceconnection);
 
-        customTabActivityHelper = new CustomTabActivityHelper();
-        customTabActivityHelper.setConnectionCallback(this);
-
         mUrlEditText = findViewById(R.id.url);
         mMayLaunchUrlButton = findViewById(R.id.button_may_launch_url);
         mMayLaunchUrlButton.setEnabled(false);
         mMayLaunchUrlButton.setOnClickListener(this);
 
         findViewById(R.id.start_custom_tab).setOnClickListener(this);
+
+        customTabActivityHelper = new CustomTabActivityHelper();
+        customTabActivityHelper.setConnectionCallback(this);
+        customTabActivityHelper.bindCustomTabsService(this);
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
         customTabActivityHelper.setConnectionCallback(null);
+        customTabActivityHelper.unbindCustomTabsService(this);
     }
 
     @Override
@@ -60,19 +63,6 @@ public class ServiceConnectionActivity extends AppCompatActivity
 
     @Override
     public void onCustomTabsDisconnected() {
-        mMayLaunchUrlButton.setEnabled(false);
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-        customTabActivityHelper.bindCustomTabsService(this);
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        customTabActivityHelper.unbindCustomTabsService(this);
         mMayLaunchUrlButton.setEnabled(false);
     }
 

--- a/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/ServiceConnectionActivity.java
+++ b/demos/custom-tabs-example-app/src/main/java/org/chromium/customtabsdemos/ServiceConnectionActivity.java
@@ -15,7 +15,6 @@ package org.chromium.customtabsdemos;
 
 import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 


### PR DESCRIPTION
**The problem**
I many cases, applications want to stay connected to the Custom Tabs service after the Custom Tabs is launched. They might want to listen for Custom Tabs callback events or enable a minimized tab to be replaced with a new one when relaunching. The existing code disconnects from the Custom Tabs service when the Activity is stopped, preventing either of those to happen.

**The solution**
Move binding and unbinding from the Custom Tabs Service to onCreate() / onDestroy(), so the application will stay connected to the service after it is backgrounded, allowing it to continue receiving callbacks and replace a minimized Custom Tab.