### PR TITLE
Forward Launch Handler client mode to a browser

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -29,14 +29,12 @@ import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsCallback;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.trusted.FileHandlingData;
-import androidx.browser.trusted.LaunchHandlerClientMode;
 import androidx.browser.trusted.TrustedWebActivityDisplayMode;
 import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
 import androidx.browser.trusted.TrustedWebActivityService;
 import androidx.browser.trusted.sharing.ShareData;
 import androidx.browser.trusted.sharing.ShareTarget;
 import androidx.core.content.ContextCompat;
-import android.content.pm.ActivityInfo;
 
 import com.google.androidbrowserhelper.trusted.splashscreens.PwaWrapperSplashScreenStrategy;
 
@@ -116,16 +114,6 @@ public class LauncherActivity extends Activity {
 
     /** See comment in onCreate. */
     private static int sLauncherActivitiesAlive;
-
-    private static final Map<String, Integer> LAUNCH_HANDLER_CLIENT_MODE_MAP =
-            Map.of(
-                    "navigate-existing", LaunchHandlerClientMode.NAVIGATE_EXISTING,
-                    "focus-existing", LaunchHandlerClientMode.FOCUS_EXISTING,
-                    "navigate-new", LaunchHandlerClientMode.NAVIGATE_NEW,
-                    "auto", LaunchHandlerClientMode.AUTO);
-
-    private static final String LAUNCH_HANDLER_CLIENT_MODE_METADATA_NAME
-            = "android.support.customtabs.trusted.LAUNCH_HANDLER_CLIENT_MODE";
 
     private LauncherActivityMetadata mMetadata;
 
@@ -231,7 +219,7 @@ public class LauncherActivity extends Activity {
                                 CustomTabsIntent.COLOR_SCHEME_DARK, darkModeColorScheme)
                         .setDisplayMode(getDisplayMode())
                         .setScreenOrientation(mMetadata.screenOrientation)
-                        .setLaunchHandlerClientMode(getLaunchHandlerClientMode());
+                        .setLaunchHandlerClientMode(mMetadata.launchHandlerClientMode);
 
        Uri intentUrl = getIntent().getData();
        if (!launchUrl.equals(intentUrl)) {
@@ -507,23 +495,5 @@ public class LauncherActivity extends Activity {
 
         startActivity(newIntent);
         return true;
-    }
-
-    private @LaunchHandlerClientMode.ClientMode int getLaunchHandlerClientMode() {
-        String clientModeName = null;
-        try {
-            PackageManager pm = getPackageManager();
-            ActivityInfo ai = pm.getActivityInfo(this.getComponentName(), PackageManager.GET_META_DATA);
-            Bundle metaData = ai.metaData;
-
-            if (metaData != null) {
-                clientModeName = metaData.getString(LAUNCH_HANDLER_CLIENT_MODE_METADATA_NAME);
-            }
-        } catch (PackageManager.NameNotFoundException e) {
-            Log.w(TAG, "Couldn't get Launch Handler Client Code from a metadata", e);
-        }
-
-        Integer clientMode = LAUNCH_HANDLER_CLIENT_MODE_MAP.get(clientModeName);
-        return clientMode != null ? clientMode : LaunchHandlerClientMode.AUTO;
     }
 }

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivityMetadata.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivityMetadata.java
@@ -24,11 +24,13 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.browser.trusted.LaunchHandlerClientMode;
 import androidx.browser.trusted.ScreenOrientation;
 import androidx.browser.trusted.TrustedWebActivityDisplayMode;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT;
 
@@ -153,6 +155,19 @@ public class LauncherActivityMetadata {
     private static final String METADATA_FILE_HANDLING_ACTION_URL =
             "android.support.customtabs.trusted.FILE_HANDLING_ACTION_URL";
 
+    /**
+     * Client mode of Launch Handler API. Describes how TWA will be launched. For example opening
+     * a new tasks or taking an action to an existing one.
+     */
+    private static final String LAUNCH_HANDLER_CLIENT_MODE_METADATA_NAME
+            = "android.support.customtabs.trusted.LAUNCH_HANDLER_CLIENT_MODE";
+    private static final Map<String, Integer> LAUNCH_HANDLER_CLIENT_MODE_MAP =
+            Map.of(
+                    "navigate-existing", LaunchHandlerClientMode.NAVIGATE_EXISTING,
+                    "focus-existing", LaunchHandlerClientMode.FOCUS_EXISTING,
+                    "navigate-new", LaunchHandlerClientMode.NAVIGATE_NEW,
+                    "auto", LaunchHandlerClientMode.AUTO);
+
     private final static int DEFAULT_COLOR_ID = android.R.color.white;
     private final static int DEFAULT_DIVIDER_COLOR_ID = android.R.color.transparent;
 
@@ -173,6 +188,7 @@ public class LauncherActivityMetadata {
     @ScreenOrientation.LockType public final int screenOrientation;
     @Nullable public final String shareTarget;
     @Nullable public final String fileHandlingActionUrl;
+    @LaunchHandlerClientMode.ClientMode public final int launchHandlerClientMode;
 
     private LauncherActivityMetadata(@NonNull Bundle metaData, @NonNull Resources resources) {
         defaultUrl = metaData.getString(METADATA_DEFAULT_URL);
@@ -205,6 +221,8 @@ public class LauncherActivityMetadata {
         int shareTargetId = metaData.getInt(METADATA_SHARE_TARGET, 0);
         shareTarget = shareTargetId == 0 ? null : resources.getString(shareTargetId);
         fileHandlingActionUrl = metaData.getString(METADATA_FILE_HANDLING_ACTION_URL);
+        launchHandlerClientMode = getLaunchHandlerClientMode(
+                metaData.getString(LAUNCH_HANDLER_CLIENT_MODE_METADATA_NAME));
     }
 
     private @ScreenOrientation.LockType int getOrientation(String orientation) {
@@ -245,6 +263,16 @@ public class LauncherActivityMetadata {
                     true, LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT);
         }
         return new TrustedWebActivityDisplayMode.DefaultMode();
+    }
+
+    /**
+     * Returns a Launch Handler client mode in androidx format. In case it's absent or wrong in the
+     * metadata LaunchHandlerClientMode.AUTO is returned.
+     */
+    private @LaunchHandlerClientMode.ClientMode int getLaunchHandlerClientMode(
+            String clientModeName) {
+        Integer clientMode = LAUNCH_HANDLER_CLIENT_MODE_MAP.get(clientModeName);
+        return clientMode != null ? clientMode : LaunchHandlerClientMode.AUTO;
     }
 
     /**


### PR DESCRIPTION
In order to support Launch Handler API we need to provide a client mode information of a TWA app metadata to an intent to a browser. It allows the browser to launch a TWA activity in a proper way.