### PR TITLE
Update Auth Tab demo browser dependency to alpha03

### DIFF
--- a/demos/custom-tabs-auth-tab/build.gradle
+++ b/demos/custom-tabs-auth-tab/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.activity:activity:1.9.3'
-    implementation 'androidx.browser:browser:1.9.0-alpha01'
+    implementation 'androidx.browser:browser:1.9.0-alpha03'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.0'

--- a/demos/custom-tabs-auth-tab/src/main/java/com/google/androidbrowserhelper/demos/customtabsauthtab/AuthManager.java
+++ b/demos/custom-tabs-auth-tab/src/main/java/com/google/androidbrowserhelper/demos/customtabsauthtab/AuthManager.java
@@ -12,7 +12,6 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.browser.auth.AuthTabIntent;
 import androidx.annotation.OptIn;
-import androidx.browser.auth.ExperimentalAuthTab;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -24,7 +23,6 @@ import java.util.UUID;
  * a comprehensive implementation of the OAuth protocol.
  */
 
-@OptIn(markerClass = ExperimentalAuthTab.class)
 public class AuthManager {
     private static final String TAG = "OAuthManager";
 

--- a/demos/custom-tabs-auth-tab/src/main/java/com/google/androidbrowserhelper/demos/customtabsauthtab/MainActivity.java
+++ b/demos/custom-tabs-auth-tab/src/main/java/com/google/androidbrowserhelper/demos/customtabsauthtab/MainActivity.java
@@ -28,9 +28,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.OptIn;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.browser.auth.AuthTabIntent;
-import androidx.browser.auth.ExperimentalAuthTab;
 
-@OptIn(markerClass = ExperimentalAuthTab.class)
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = "MainActivity";
 


### PR DESCRIPTION
This PR updates androidx.browser dependency version to 1.9.0-alpha03 and removes the ExperimentalAuthTab annotation.