### PR TITLE
Use a task id as a session id

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -268,7 +268,7 @@ public class LauncherActivity extends Activity {
     }
 
     protected TwaLauncher createTwaLauncher() {
-        return new TwaLauncher(this);
+        return new TwaLauncher(this, getTaskId());
     }
 
     private boolean splashScreenNeeded() {


### PR DESCRIPTION
Since we are going to have several tasks of the same TWA in parallel we'll need to have separate sessions for each task. Therefore we will use task id value which is a hex number for session  id instead.