### PR TITLE
Add an extra data for TWA startup timestamp

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -29,6 +29,8 @@ android {
         versionCode 1
         versionName VERSION
 
+        buildConfigField "int", "LIBRARY_VERSION", "${versionCode}"
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -37,6 +39,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 
     compileOptions {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -20,6 +20,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Matrix;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.util.Log;
 import android.widget.ImageView;
 
@@ -125,10 +126,13 @@ public class LauncherActivity extends Activity {
     @Nullable
     private TwaLauncher mTwaLauncher;
 
+    private long mStartupUptimeMillis;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        mStartupUptimeMillis = SystemClock.uptimeMillis();
         sLauncherActivitiesAlive++;
         boolean twaAlreadyRunning = sLauncherActivitiesAlive > 1;
         boolean intentHasData = getIntent().getData() != null;
@@ -235,6 +239,7 @@ public class LauncherActivity extends Activity {
         addFileDataIfPresent(twaBuilder);
 
         mTwaLauncher = createTwaLauncher();
+        mTwaLauncher.setStartupUptimeMillis(mStartupUptimeMillis);
         mTwaLauncher.launch(twaBuilder,
                 getCustomTabsCallback(),
                 mSplashScreenStrategy,


### PR DESCRIPTION
Add an extra data for the timestamp for TWA startup. This extra data will be passed to the browser to calculate various metrics e.g. the duration from TWA launch to FCP.