### PR TITLE
Preload url while waiting for enter animation complete

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/splashscreens/PwaWrapperSplashScreenStrategy.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/splashscreens/PwaWrapperSplashScreenStrategy.java
@@ -19,6 +19,7 @@ import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.Matrix;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -192,11 +193,11 @@ public class PwaWrapperSplashScreenStrategy implements SplashScreenStrategy {
                 mProviderPackage);
 
         mSplashImageTransferTask.execute(
-                success -> onSplashImageTransferred(builder, success, onReadyCallback));
+                success -> onSplashImageTransferred(builder, success, onReadyCallback, session));
     }
 
     private void onSplashImageTransferred(TrustedWebActivityIntentBuilder builder, boolean success,
-            Runnable onReadyCallback) {
+            Runnable onReadyCallback, CustomTabsSession session) {
         if (!success) {
             Log.w(TAG, "Failed to transfer splash image.");
             onReadyCallback.run();
@@ -204,17 +205,22 @@ public class PwaWrapperSplashScreenStrategy implements SplashScreenStrategy {
         }
         builder.setSplashScreenParams(makeSplashScreenParamsBundle());
 
-        runWhenEnterAnimationComplete(() -> {
-            onReadyCallback.run();
-            mActivity.overridePendingTransition(0, 0); // Avoid window animations during transition.
-        });
+        Runnable taskToRun = () -> {
+          onReadyCallback.run();
+          mActivity.overridePendingTransition(0, 0); // Avoid window animations during transition.
+        };
+
+        runWhenEnterAnimationComplete(taskToRun, session, builder.getUri());
     }
 
-    private void runWhenEnterAnimationComplete(Runnable runnable) {
+    private void runWhenEnterAnimationComplete(Runnable runnable, CustomTabsSession session,
+            Uri uri) {
         if (mEnterAnimationComplete) {
             runnable.run();
         } else {
             mOnEnterAnimationCompleteRunnable = runnable;
+            boolean preloadResult = session.mayLaunchUrl(uri, null, null);
+            Log.i(TAG, "Enter animation not complete, try preload url. Result: " + preloadResult);
         }
     }
 


### PR DESCRIPTION
While app is waiting for enter animation complete, the chrome can preload the url. It could make web content loading around 300ms faster, which helps improve the app start-up time.