### PR TITLE
Fix the androidTest build

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -68,6 +68,7 @@ dependencies {
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.core:core:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.0.0'

--- a/androidbrowserhelper/src/androidTest/AndroidManifest.xml
+++ b/androidbrowserhelper/src/androidTest/AndroidManifest.xml
@@ -14,10 +14,22 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="android.support.customtabs">
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-sdk android:minSdkVersion="16"/>
 
     <application>
+        <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity"
+            android:exported="true"
+            tools:node="merge"
+            tools:replace="android:exported" />
+        <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity"
+            android:exported="true"
+            tools:node="merge"
+            tools:replace="android:exported" />
+        <activity android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity"
+            android:exported="true"
+            tools:node="merge"
+            tools:replace="android:exported" />
 
         <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
             <meta-data
@@ -26,7 +38,7 @@
         </activity>
 
         <activity android:name="com.google.androidbrowserhelper.trusted.testcomponents.TestActivity"
-                  android:enabled="false">
+                  android:enabled="false" android:exported="true">
             <!-- A browsable intent filter is required for the DelegationService. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
@@ -43,14 +55,14 @@
         </activity>
 
         <service android:name="com.google.androidbrowserhelper.trusted.testcomponents.TestCustomTabsService"
-                 android:enabled="false">
+                 android:enabled="false" android:exported="true">
             <intent-filter>
                 <category android:name="androidx.browser.trusted.category.TrustedWebActivities" />
             </intent-filter>
         </service>
 
         <service android:name="com.google.androidbrowserhelper.trusted.testcomponents.TestCustomTabsServiceSupportsTwas"
-                 android:enabled="false">
+                 android:enabled="false" android:exported="true">
             <intent-filter>
                 <action android:name="android.support.customtabs.action.CustomTabsService" />
                 <category android:name="androidx.browser.trusted.category.TrustedWebActivities" />
@@ -60,7 +72,7 @@
         </service>
 
         <service android:name="com.google.androidbrowserhelper.trusted.testcomponents.TestCustomTabsServiceNoSplashScreens"
-                 android:enabled="false">
+                 android:enabled="false" android:exported="true">
             <intent-filter>
                 <action android:name="android.support.customtabs.action.CustomTabsService" />
                 <category android:name="androidx.browser.trusted.category.TrustedWebActivities" />
@@ -82,9 +94,10 @@
         </activity>
 
         <activity android:name="com.google.androidbrowserhelper.trusted.LauncherActivity"
-                  android:label="Test Launcher Activity"
                   android:theme="@style/Theme.AppCompat.Light"
-                  android:enabled="false">
+                  android:label="Test Launcher Activity"
+                  android:enabled="false"
+                  android:exported="true">
 
             <meta-data android:name="android.support.customtabs.trusted.DEFAULT_URL"
                        android:value="https://www.test.com/default_url/" />

--- a/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/splashscreens/PwaWrapperSplashScreenStrategyTest.java
+++ b/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/splashscreens/PwaWrapperSplashScreenStrategyTest.java
@@ -100,7 +100,7 @@ public class PwaWrapperSplashScreenStrategyTest {
         mActivity = mActivityTestRule.getActivity();
         mSession = mConnectionRule.establishSessionBlocking(mActivity);
         mStrategy = new PwaWrapperSplashScreenStrategy(mActivity, R.drawable.splash, 0,
-                ImageView.ScaleType.FIT_XY, null, 0, FILE_PROVIDER_AUTHORITY);
+                ImageView.ScaleType.FIT_XY, null, 0, FILE_PROVIDER_AUTHORITY, false);
     }
 
     @After
@@ -145,7 +145,7 @@ public class PwaWrapperSplashScreenStrategyTest {
 
         PwaWrapperSplashScreenStrategy strategy = new PwaWrapperSplashScreenStrategy(mActivity,
                 R.drawable.splash, bgColor, scaleType, matrix, fadeOutDuration,
-                FILE_PROVIDER_AUTHORITY);
+                FILE_PROVIDER_AUTHORITY, false);
         strategy.onActivityEnterAnimationComplete();
         initiateLaunch(strategy);
 


### PR DESCRIPTION
1. Remove package namespace definition in Manifest. Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.

2. Specify an explicit value for `android:exported` when the component has an intent filter defined.

3. Add androidx.appcompat:appcompat build dependency in build.gradle

4. Complete the PwaWrapperSplashScreenStrategy()'s startChromeBeforeAnimationComplete argument in test