### PR TITLE
Finish LauncherActivity after browser is started

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -243,7 +243,7 @@ public class LauncherActivity extends Activity {
         mTwaLauncher.launch(twaBuilder,
                 getCustomTabsCallback(),
                 mSplashScreenStrategy,
-                () -> mBrowserWasLaunched = true,
+                () -> {mBrowserWasLaunched = true; finish();},
                 getFallbackStrategy());
 
         if (!sChromeVersionChecked) {


### PR DESCRIPTION
Finishing the LauncherActivity after starting the browser ensures that subsequent intents are correctly delivered to the existing session onNewIntent method.