### PR TITLE
Use unique name for the string resource "app_name".

### DIFF
--- a/androidbrowserhelper/src/main/res/values/strings.xml
+++ b/androidbrowserhelper/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Android Browser Helper</string>
+    <string name="android_browser_helperi_app_name">Android Browser Helper</string>
     <string name="update_chrome_toast">Please update to Chrome Stable 72 or later.</string>
     <string name="no_provider_toast">Please install Chrome Stable 72 or later.</string>
     <string name="manage_space_not_supported_toast">This app\'s data is stored in %1$s.</string>


### PR DESCRIPTION
Having "app_name" is quite common and it can cause conflicts in apps that want to use this library or other libraries those app depend on.

This change will avoid conflicts with other libraries or apps.