### PR TITLE
Remove jcenter repository #494

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -14,8 +14,10 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'maven-publish'
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+}
 
 // Before 2.6.1, the version code was unused and was kept at 1.
 // This is now being used to report metrics, and should be bumped with

--- a/build.gradle
+++ b/build.gradle
@@ -14,31 +14,10 @@
  *    limitations under the License.
  */
 
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript { 
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.1'
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-
-        // Repository for DexMaker
-        maven {
-            url = "https://linkedin.jfrog.io/artifactory/open-source/"
-            content {
-                includeGroup 'com.linkedin.dexmaker'
-            }
-        }
-    }
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.google.services) apply false
 }
 
 task clean(type: Delete) {

--- a/demos/custom-tabs-auth-tab/build.gradle
+++ b/demos/custom-tabs-auth-tab/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace 'com.google.androidbrowserhelper.demos.customtabsauthtab'

--- a/demos/custom-tabs-ephemeral-with-fallback/build.gradle
+++ b/demos/custom-tabs-ephemeral-with-fallback/build.gradle
@@ -15,7 +15,9 @@
  */
 
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace 'com.google.androidbrowserhelper.demos.customtabsephemeralwithfallback'

--- a/demos/custom-tabs-ephemeral/build.gradle
+++ b/demos/custom-tabs-ephemeral/build.gradle
@@ -15,7 +15,9 @@
  */
 
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace 'com.google.androidbrowserhelper.demos.customtabsephemeral'

--- a/demos/custom-tabs-example-app/build.gradle
+++ b/demos/custom-tabs-example-app/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "org.chromium.customtabsdemos"

--- a/demos/custom-tabs-headers/build.gradle
+++ b/demos/custom-tabs-headers/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.androidbrowserhelper.demos.customtabsheaders"

--- a/demos/custom-tabs-navigation-callbacks/build.gradle
+++ b/demos/custom-tabs-navigation-callbacks/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.androidbrowserhelper.demos.customtabssession"

--- a/demos/custom-tabs-oauth/build.gradle
+++ b/demos/custom-tabs-oauth/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.androidbrowserhelper.demos.customtabsoauth"

--- a/demos/custom-tabs-session/build.gradle
+++ b/demos/custom-tabs-session/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.androidbrowserhelper.demos.customtabssession"

--- a/demos/twa-basic/build.gradle
+++ b/demos/twa-basic/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.browser.examples.twa_basic"

--- a/demos/twa-custom-launcher/build.gradle
+++ b/demos/twa-custom-launcher/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.androidbrowserhelper.demo"

--- a/demos/twa-firebase-analytics/build.gradle
+++ b/demos/twa-firebase-analytics/build.gradle
@@ -14,16 +14,8 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
-
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.google.gms:google-services:4.3.4'
-    }
+plugins {
+    id 'com.android.application'
 }
 
 android {

--- a/demos/twa-location-delegation/build.gradle
+++ b/demos/twa-location-delegation/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.browser.examples.twa_location_delegation"

--- a/demos/twa-multi-domain/build.gradle
+++ b/demos/twa-multi-domain/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.browser.examples.twa_multi_domain"

--- a/demos/twa-notification-delegation/build.gradle
+++ b/demos/twa-notification-delegation/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace 'com.google.androidbrowserhelper.demos.twa_notification_delegation'

--- a/demos/twa-orientation/build.gradle
+++ b/demos/twa-orientation/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.browser.examples.twa_orientation"

--- a/demos/twa-play-billing/build.gradle
+++ b/demos/twa-play-billing/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // Switch these around for a build to upload to the Play Store.
 def appId = "com.google.androidbrowserhelper.demos.playbilling"

--- a/demos/twa-web-share-target/build.gradle
+++ b/demos/twa-web-share-target/build.gradle
@@ -14,7 +14,9 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.androidbrowserhelper.webshare"

--- a/demos/twa-webview-fallback/build.gradle
+++ b/demos/twa-webview-fallback/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.google.browser.examples.twawebviewfallback"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+agp = "8.9.1"
 androidx-activity = "1.9.3"
 androidx-annotation = "1.9.1"
 androidx-appcompat = "1.7.0"
@@ -8,7 +9,7 @@ androidx-core = "1.10.1"
 androidx-recyclerview = "1.1.0"
 androidx-test-espresso-core = "3.2.0"
 androidx-test-core = "1.4.0"
-androidx-ext-junit= "1.1.1"
+androidx-ext-junit = "1.1.1"
 androidx-test-rules = "1.2.0"
 androidx-test-runner = "1.2.0"
 billing = "7.1.1"
@@ -29,7 +30,7 @@ robolectric = "4.12.2"
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
-androidx-browser = { group="androidx.browser", name="browser", version.ref="androidx-browser" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidx-browser" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-ext-junit" }
@@ -45,10 +46,16 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 google-services = { module = "com.google.gms:google-services", version.ref = "google-services" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit = { module = "junit:junit", version.ref = "junit" }
-kotlin-bom = { group="org.jetbrains.kotlin", name="kotlin-bom", version.ref="kotlin-bom" }
-kotlin-coroutines-bom = { group="org.jetbrains.kotlinx", name="kotlinx-coroutines-bom", version.ref="kotlin-coroutines-bom" }
+kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin-bom" }
+kotlin-coroutines-bom = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-bom", version.ref = "kotlin-coroutines-bom" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito-inline" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "play-services-location" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
+maven-publish = { id = "maven-publish" }

--- a/locationdelegation/build.gradle
+++ b/locationdelegation/build.gradle
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-apply plugin: 'com.android.library'
-apply plugin: 'maven-publish'
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+}
 
 def VERSION = "1.1.2";
 

--- a/playbilling/build.gradle
+++ b/playbilling/build.gradle
@@ -14,8 +14,10 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'maven-publish'
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+}
 
 def VERSION = "1.1.0";
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,32 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "android-browser-helper"
+
+dependencyResolutionManagement {
+    repositories {
+        repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+        google()
+        mavenCentral()
+
+        // Repository for DexMaker
+        maven {
+            url = "https://linkedin.jfrog.io/artifactory/open-source/"
+            content {
+                includeGroup 'com.linkedin.dexmaker'
+            }
+        }
+    }
+}
+
 include ':androidbrowserhelper'
 include ':locationdelegation'
 include ':playbilling'


### PR DESCRIPTION
Removing jcenter and migrating build.gradle scripts to a new API. This should finally prevent us from regressing on random version changes and keep single set of repos and plugins.