### PR TITLE
Add getUrlForIntent to allow arbitrary mapping from Intent to URL

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -226,7 +226,7 @@ public class LauncherActivity extends Activity {
                         .setScreenOrientation(mMetadata.screenOrientation)
                         .setLaunchHandlerClientMode(mMetadata.launchHandlerClientMode);
 
-       Uri intentUrl = getIntent().getData();
+       Uri intentUrl = getUrlForIntent(getIntent());
        if (!launchUrl.equals(intentUrl)) {
             twaBuilder.setOriginalLaunchUrl(intentUrl);
        }
@@ -394,6 +394,15 @@ public class LauncherActivity extends Activity {
         return Collections.emptyMap();
     }
 
+    /**
+     * Override this to define a custom mapping from intent to URL (e.g., based on intent action).
+     * The returned URL may be further modified by the Protocol Handler support.
+     */
+    @Nullable
+    protected Uri getUrlForIntent(Intent intent) {
+        return intent.getData();
+    }
+
     @Override
     public void onEnterAnimationComplete() {
         super.onEnterAnimationComplete();
@@ -404,8 +413,8 @@ public class LauncherActivity extends Activity {
 
     /**
      * Returns the URL that the Trusted Web Activity should be launched to. By default this
-     * implementation checks to see if the Activity was launched with an Intent with data, if so
-     * attempt to launch to that URL. If not, read the
+     * implementation checks to see if there is a URL specified for the Intent that launched the
+     * Activity, and if so attempts to launch to that URL. If not, reads the
      * "android.support.customtabs.trusted.DEFAULT_URL" metadata from the manifest.
      *
      * Override this for special handling (such as ignoring or sanitising data from the Intent).
@@ -413,7 +422,7 @@ public class LauncherActivity extends Activity {
     protected Uri getLaunchingUrl() {
         Uri defaultUrl = Uri.parse(mMetadata.defaultUrl);
 
-        Uri intentUrl = getIntent().getData();
+        Uri intentUrl = getUrlForIntent(getIntent());
 
         if (intentUrl != null) {
             Map<String, Uri> protocolHandlers = getProtocolHandlers();


### PR DESCRIPTION
`LauncherActivity.getLaunchingUrl()` currently allows overriding the default URL only when the incoming intent specifies a URL as the data. This change introduces `getUrlForIntent()` to allow subclasses to define an arbitrarily mapping from intent to URL (e.g., based on intent action).