### PR TITLE
Finish LauncherActivity after TWA is started

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -243,7 +243,7 @@ public class LauncherActivity extends Activity {
         mTwaLauncher.launch(twaBuilder,
                 getCustomTabsCallback(),
                 mSplashScreenStrategy,
-                () -> mBrowserWasLaunched = true,
+                () -> { mBrowserWasLaunched = true; finish();},
                 getFallbackStrategy());
 
         if (!sChromeVersionChecked) {


### PR DESCRIPTION
In the case when an app is a TWA-powered PWA generated by bubblewrap and a browser sends an intent to LauncherActivity with flag CLEAR_TOP and LauncherActivity instance remains in a task stack below browser's activity all browser's activities on top of LauncherActivity will be removed. Because LauncherActivity itself doesn't contain any useful data, the app loses all user progress, which is stored in the browser's activity. If LauncherActivity is finished just after a TWA is started a new instance of it will be created on top of browser's activity. The intent will then be delivered to the same instance of browser's activity withing the same TWA session, without losing user progress.