### PR TITLE
Bump version to 2.7.0-alpha01

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -22,7 +22,7 @@ plugins {
 // Before 2.6.1, the version code was unused and was kept at 1.
 // This is now being used to report metrics, and should be bumped with
 // every version bump.
-def VERSION = "2.6.2";
+def VERSION = "2.7.0-alpha01";
 def VERSION_CODE = 2;
 
 android {


### PR DESCRIPTION
This creates a new alpha version, GH tag/release to be done once this lands.

An alpha release is necessary to publish changes dependent on the alpha release of `androidx.browser`.

Publishing to maven will need to be done by a repo owner

cc @gstepniewski-google 