### PR TITLE
Fix display override resource access

### DIFF
--- a/androidbrowserhelper/build.gradle
+++ b/androidbrowserhelper/build.gradle
@@ -22,8 +22,8 @@ plugins {
 // Before 2.6.1, the version code was unused and was kept at 1.
 // This is now being used to report metrics, and should be bumped with
 // every version bump.
-def VERSION = "2.7.0-alpha01";
-def VERSION_CODE = 3;
+def VERSION = "2.7.0-alpha02";
+def VERSION_CODE = 4;
 
 android {
     namespace "com.google.androidbrowserhelper"

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivityMetadata.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivityMetadata.java
@@ -234,7 +234,7 @@ public class LauncherActivityMetadata {
         }
         fallbackStrategyType = metaData.getString(METADATA_FALLBACK_STRATEGY);
         displayMode = getDisplayMode(metaData.getString(METADATA_DISPLAY_MODE), /* includeExperimental= */ false);
-        displayOverrideList = getDisplayOverride(metaData);
+        displayOverrideList = getDisplayOverride(metaData, resources);
         screenOrientation = getOrientation(metaData.getString(METADATA_SCREEN_ORIENTATION));
         int shareTargetId = metaData.getInt(METADATA_SHARE_TARGET, 0);
         shareTarget = shareTargetId == 0 ? null : resources.getString(shareTargetId);
@@ -300,11 +300,13 @@ public class LauncherActivityMetadata {
         return new TrustedWebActivityDisplayMode.DefaultMode();
     }
 
-    private static List<TrustedWebActivityDisplayMode> getDisplayOverride(@NonNull Bundle metaData) {
-        String[] displayOverrideStringArray = metaData.getStringArray(METADATA_DISPLAY_OVERRIDE);
-        if (displayOverrideStringArray == null) {
+    private static List<TrustedWebActivityDisplayMode> getDisplayOverride(@NonNull Bundle metaData, @NonNull Resources resources) {
+        if (!metaData.containsKey(METADATA_DISPLAY_OVERRIDE)) {
             return new ArrayList<>();
         }
+
+        int displayOverrideResourceId = metaData.getInt(METADATA_DISPLAY_OVERRIDE);
+        String[] displayOverrideStringArray = resources.getStringArray(displayOverrideResourceId);
 
         List<TrustedWebActivityDisplayMode> displayOverrideList = new ArrayList<>();
         for (String displayOverrideString : displayOverrideStringArray) {


### PR DESCRIPTION
This was an oversight in https://github.com/GoogleChrome/android-browser-helper/pull/547. The actual string array is stored in the resources, it's not directly accessible from metadata.

This PR fixes the issue, and bumps the alpha version.