### PR TITLE
Shortcut label: Site Settings -> Site settings

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/ManageDataLauncherActivity.java
@@ -356,7 +356,7 @@ public class ManageDataLauncherActivity extends Activity {
         int shortcutIconId = context.getResources().getIdentifier(
                 OVERRIDE_IC_SITE_SETTINGS_ID, "drawable", context.getPackageName());
         return new ShortcutInfo.Builder(context, SITE_SETTINGS_SHORTCUT_ID)
-                .setShortLabel("Site Settings")
+                .setShortLabel("Site settings")
                 .setLongLabel("Manage website notifications, permissions, etc.")
                 .setIcon(Icon.createWithResource(context,
                         shortcutIconId != 0 ? shortcutIconId : R.drawable.ic_site_settings))


### PR DESCRIPTION
Improve consistency with the "Site settings" label on WebAPKs and other items from Android (like "App info" and "Pause app")
<img width="680" height="726" alt="Current WebAPK example" src="https://github.com/user-attachments/assets/03fe3dbb-e81e-491b-b55b-a92bc11979c5" />
