### PR TITLE
Add a dialogue for when custom tab fallback fails.

### DIFF
--- a/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/TwaLauncherTest.java
+++ b/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/TwaLauncherTest.java
@@ -294,30 +294,19 @@ public class TwaLauncherTest {
         doReturn(Collections.emptyList()).when(pmSpy).queryIntentServices(any(), anyInt());
         doReturn(Collections.emptyList()).when(pmSpy).queryIntentActivities(any(), anyInt());
         doReturn(null).when(pmSpy).resolveActivity(any(), anyInt());
-
-        // Create a spy of the activity and have it return the mocked PackageManager.
         TestActivity activitySpy = spy(mActivity);
         doReturn(pmSpy).when(activitySpy).getPackageManager();
-        // Force the activity to return our spy when getApplicationContext() is called.
-        // Libraries like CustomTabsClient often call getApplicationContext().getPackageManager().
         doReturn(activitySpy).when(activitySpy).getApplicationContext();
-
-        // 1. Setup a Mock of the strategy
         TwaLauncher.BrowserUnavailableDialogStrategy mockStrategy =
                 mock(TwaLauncher.BrowserUnavailableDialogStrategy.class);
         TwaLauncher.setDialogStrategyForTesting(mockStrategy);
-
         TwaLauncher launcher = new TwaLauncher(activitySpy);
 
-        // 2. Launch the launcher
         mActivity.runOnUiThread(() -> launcher.launch(new TrustedWebActivityIntentBuilder(URL),
                 mCustomTabsCallback, null, null, TwaLauncher.CCT_FALLBACK_STRATEGY));
 
-        // 3. Verify the logic triggered the strategy
         InstrumentationRegistry.getInstrumentation().waitForIdleSync();
         verify(mockStrategy).show(any());
-
-        // We've verified the fallback was triggered.
         assertNotNull(launcher);
     }
 

--- a/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/TwaLauncherTest.java
+++ b/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/TwaLauncherTest.java
@@ -22,8 +22,10 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -33,6 +35,7 @@ import static androidx.browser.customtabs.TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTE
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 
 import com.google.androidbrowserhelper.trusted.splashscreens.SplashScreenStrategy;
@@ -57,6 +60,7 @@ import androidx.test.filters.MediumTest;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -100,6 +104,7 @@ public class TwaLauncherTest {
     @After
     public void tearDown() {
         TwaProviderPicker.restrictToPackageForTesting(null);
+        TwaLauncher.setDialogStrategyForTesting(null);
         mTwaLauncher.destroy();
     }
 
@@ -143,7 +148,8 @@ public class TwaLauncherTest {
     public void fallsBackToCustomTab_whenSessionCreationFails() {
         TestCustomTabsService.setCanCreateSessions(false);
 
-        Runnable launchRunnable = () -> mTwaLauncher.launch(URL);
+        Runnable launchRunnable = () -> mTwaLauncher.launch(new TrustedWebActivityIntentBuilder(URL),
+                mCustomTabsCallback, null, null, TwaLauncher.CCT_FALLBACK_STRATEGY);
         TestBrowser browser = getBrowserActivityWhenLaunched(launchRunnable);
         assertFalse(browser.getIntent().getBooleanExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY,
                 false));
@@ -274,6 +280,46 @@ public class TwaLauncherTest {
         mTwaLauncher.launch(builder, mCustomTabsCallback, strategy, null);
         assertTrue(latch.await(3, TimeUnit.SECONDS));
         verify(builder, never()).build(any());
+    }
+
+    @Test
+    public void showsBrowserUnavailableDialog() throws Exception {
+        // Disable all browsers and services in the test package.
+        mEnableComponents.manuallyDisable(TestBrowser.class);
+        mEnableComponents.manuallyDisable(TestCustomTabsServiceSupportsTwas.class);
+        mEnableComponents.manuallyDisable(TestCustomTabsService.class);
+
+        // Mock PackageManager to return no Custom Tabs providers and no browsers.
+        // This forces CustomTabsClient.getPackageName to return null.
+        PackageManager pmSpy = spy(mContext.getPackageManager());
+        doReturn(Collections.emptyList()).when(pmSpy).queryIntentServices(any(), anyInt());
+        doReturn(Collections.emptyList()).when(pmSpy).queryIntentActivities(any(), anyInt());
+        doReturn(null).when(pmSpy).resolveActivity(any(), anyInt());
+
+        // Create a spy of the activity and have it return the mocked PackageManager.
+        TestActivity activitySpy = spy(mActivity);
+        doReturn(pmSpy).when(activitySpy).getPackageManager();
+        // Force the activity to return our spy when getApplicationContext() is called.
+        // Libraries like CustomTabsClient often call getApplicationContext().getPackageManager().
+        doReturn(activitySpy).when(activitySpy).getApplicationContext();
+
+        // 1. Setup a Mock of the strategy
+        TwaLauncher.BrowserUnavailableDialogStrategy mockStrategy =
+                mock(TwaLauncher.BrowserUnavailableDialogStrategy.class);
+        TwaLauncher.setDialogStrategyForTesting(mockStrategy);
+
+        TwaLauncher launcher = new TwaLauncher(activitySpy);
+
+        // 2. Launch the launcher
+        mActivity.runOnUiThread(() -> launcher.launch(new TrustedWebActivityIntentBuilder(URL),
+                mCustomTabsCallback, null, null, TwaLauncher.CCT_FALLBACK_STRATEGY));
+
+        // 3. Verify the logic triggered the strategy
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        verify(mockStrategy).show(any());
+
+        // We've verified the fallback was triggered.
+        assertNotNull(launcher);
     }
 
     private TrustedWebActivityIntentBuilder makeBuilder() {

--- a/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/TwaLauncherTest.java
+++ b/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/TwaLauncherTest.java
@@ -148,8 +148,7 @@ public class TwaLauncherTest {
     public void fallsBackToCustomTab_whenSessionCreationFails() {
         TestCustomTabsService.setCanCreateSessions(false);
 
-        Runnable launchRunnable = () -> mTwaLauncher.launch(new TrustedWebActivityIntentBuilder(URL),
-                mCustomTabsCallback, null, null, TwaLauncher.CCT_FALLBACK_STRATEGY);
+        Runnable launchRunnable = () -> mTwaLauncher.launch(URL);
         TestBrowser browser = getBrowserActivityWhenLaunched(launchRunnable);
         assertFalse(browser.getIntent().getBooleanExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY,
                 false));

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -67,9 +67,11 @@ public class TwaLauncher {
      */
     private static final String ACTION_SUPERVISION_SETTINGS = "android.settings.SUPERVISION_SETTINGS";
 
-    /** Strategy for showing a dialog when no browser is available. */
+    /** 
+     * Strategy for showing a dialog when no browser is available. Interface exists just to
+     * facilitate unit testing.
+     */
     public interface BrowserUnavailableDialogStrategy {
-        /** Shows the dialog. */
         void show(Activity activity);
     }
 
@@ -387,6 +389,8 @@ public class TwaLauncher {
     private static void showBrowserUnavailableDialog(Activity activity) {
         PackageManager pm = activity.getPackageManager();
 
+        // Query for all browsers that can handle a standard URL. This allows us to find the
+        // user's preferred browser to provide a helpful name in the dialog.
         Intent queryBrowsersIntent = new Intent()
                 .setAction(Intent.ACTION_VIEW)
                 .addCategory(Intent.CATEGORY_BROWSABLE)
@@ -395,17 +399,16 @@ public class TwaLauncher {
         List<ResolveInfo> allBrowsers = pm.queryIntentActivities(queryBrowsersIntent,
                 PackageManager.MATCH_DEFAULT_ONLY | PackageManager.MATCH_UNINSTALLED_PACKAGES);
 
-        for (ResolveInfo info : allBrowsers) {}
-
-        String browserName = "Chrome";
+        String browserName = activity.getString(R.string.provider_unavailable_default_browser);
         if (!allBrowsers.isEmpty()) {
+            // The list is ordered from best to worst match, so we pick the first one.
             browserName = allBrowsers.get(0).loadLabel(pm).toString();
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
         builder.setTitle(R.string.provider_unavailable_title)
                 .setMessage(activity.getString(R.string.provider_unavailable_message, browserName))
-                .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
+                .setPositiveButton(R.string.provider_unavailable_button_ok, (dialog, which) -> dialog.dismiss())
                 .setCancelable(true)
                 .setNeutralButton(R.string.view_app_limits, (dialog, which) -> {
                     try {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -61,6 +61,12 @@ public class TwaLauncher {
     private static final String EXTRA_ANDROID_BROWSER_HELPER_VERSION =
             "org.chromium.chrome.browser.ANDROID_BROWSER_HELPER_VERSION";
 
+    /**
+     * Intent action to open parental control settings. This is used when no browser is available,
+     * which often happens when a parent has blocked browser access on a child's device.
+     */
+    private static final String ACTION_SUPERVISION_SETTINGS = "android.settings.SUPERVISION_SETTINGS";
+
     /** Strategy for showing a dialog when no browser is available. */
     public interface BrowserUnavailableDialogStrategy {
         /** Shows the dialog. */
@@ -403,7 +409,7 @@ public class TwaLauncher {
                 .setCancelable(true)
                 .setNeutralButton(R.string.view_app_limits, (dialog, which) -> {
                     try {
-                        Intent intent = new Intent("android.settings.SUPERVISION_SETTINGS");
+                        Intent intent = new Intent(ACTION_SUPERVISION_SETTINGS);
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         activity.startActivity(intent);
                     } catch (ActivityNotFoundException e) {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -14,9 +14,15 @@
 
 package com.google.androidbrowserhelper.trusted;
 
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.util.Log;
 
@@ -34,8 +40,11 @@ import androidx.browser.trusted.Token;
 import androidx.browser.trusted.TokenStore;
 import androidx.browser.trusted.TrustedWebActivityIntent;
 import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
+import com.google.androidbrowserhelper.R;
+import java.util.List;
 
 import com.google.androidbrowserhelper.BuildConfig;
+import androidx.annotation.VisibleForTesting;
 
 /**
  * Encapsulates the steps necessary to launch a Trusted Web Activity, such as establishing a
@@ -52,8 +61,34 @@ public class TwaLauncher {
     private static final String EXTRA_ANDROID_BROWSER_HELPER_VERSION =
             "org.chromium.chrome.browser.ANDROID_BROWSER_HELPER_VERSION";
 
+    /** Strategy for showing a dialog when no browser is available. */
+    public interface BrowserUnavailableDialogStrategy {
+        /** Shows the dialog. */
+        void show(Activity activity);
+    }
+
+    private static BrowserUnavailableDialogStrategy sDialogStrategy =
+            TwaLauncher::showBrowserUnavailableDialog;
+
+    /** For testing: allows mocking the dialog show. */
+    @VisibleForTesting
+    public static void setDialogStrategyForTesting(BrowserUnavailableDialogStrategy strategy) {
+        sDialogStrategy = strategy;
+    }
+
     public static final FallbackStrategy CCT_FALLBACK_STRATEGY =
             (context, twaBuilder, providerPackage, completionCallback) -> {
+        if (providerPackage == null) {
+            providerPackage = CustomTabsClient.getPackageName(context, null);
+        }
+        if (providerPackage == null) {
+            if (context instanceof Activity) {
+                sDialogStrategy.show((Activity) context);
+            } else {
+                Log.e(TAG, "Cannot show browser unavailable dialog without an Activity context.");
+            }
+            return;
+        }
         // CustomTabsIntent will fall back to launching the Browser if there are no Custom Tabs
         // providers installed.
         CustomTabsIntent intent = twaBuilder.buildCustomTabsIntent();
@@ -336,6 +371,47 @@ public class TwaLauncher {
      */
     public void setStartupUptimeMillis(long startupUptimeMillis) {
         mStartupUptimeMillis = startupUptimeMillis;
+    }
+
+    /**
+     * Shows a dialog explaining that no browser is available to open the URL.
+     *
+     * @param activity The {@link Activity} used to show the dialog.
+     */
+    private static void showBrowserUnavailableDialog(Activity activity) {
+        PackageManager pm = activity.getPackageManager();
+
+        Intent queryBrowsersIntent = new Intent()
+                .setAction(Intent.ACTION_VIEW)
+                .addCategory(Intent.CATEGORY_BROWSABLE)
+                .setData(Uri.fromParts("http", "", null));
+
+        List<ResolveInfo> allBrowsers = pm.queryIntentActivities(queryBrowsersIntent,
+                PackageManager.MATCH_DEFAULT_ONLY | PackageManager.MATCH_UNINSTALLED_PACKAGES);
+
+        for (ResolveInfo info : allBrowsers) {}
+
+        String browserName = "Chrome";
+        if (!allBrowsers.isEmpty()) {
+            browserName = allBrowsers.get(0).loadLabel(pm).toString();
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        builder.setTitle(R.string.provider_unavailable_title)
+                .setMessage(activity.getString(R.string.provider_unavailable_message, browserName))
+                .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
+                .setCancelable(true)
+                .setNeutralButton(R.string.view_app_limits, (dialog, which) -> {
+                    try {
+                        Intent intent = new Intent("android.settings.SUPERVISION_SETTINGS");
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        activity.startActivity(intent);
+                    } catch (ActivityNotFoundException e) {
+                        Log.e(TAG, "Could not launch parental controls", e);
+                    }
+                });
+        builder.setOnDismissListener(dialog -> activity.finish());
+        builder.show();
     }
 
     private class TwaCustomTabsServiceConnection extends CustomTabsServiceConnection {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -61,11 +61,7 @@ public class TwaLauncher {
     private static final String EXTRA_ANDROID_BROWSER_HELPER_VERSION =
             "org.chromium.chrome.browser.ANDROID_BROWSER_HELPER_VERSION";
 
-    /**
-     * Intent action to open parental control settings. This is used when no browser is available,
-     * which often happens when a parent has blocked browser access on a child's device.
-     */
-    private static final String ACTION_SUPERVISION_SETTINGS = "android.settings.SUPERVISION_SETTINGS";
+
 
     /** 
      * Strategy for showing a dialog when no browser is available. Interface exists just to
@@ -409,16 +405,7 @@ public class TwaLauncher {
         builder.setTitle(R.string.provider_unavailable_title)
                 .setMessage(activity.getString(R.string.provider_unavailable_message, browserName))
                 .setPositiveButton(R.string.provider_unavailable_button_ok, (dialog, which) -> dialog.dismiss())
-                .setCancelable(true)
-                .setNeutralButton(R.string.view_app_limits, (dialog, which) -> {
-                    try {
-                        Intent intent = new Intent(ACTION_SUPERVISION_SETTINGS);
-                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        activity.startActivity(intent);
-                    } catch (ActivityNotFoundException e) {
-                        Log.e(TAG, "Could not launch parental controls", e);
-                    }
-                });
+                .setCancelable(true);
         builder.setOnDismissListener(dialog -> activity.finish());
         builder.show();
     }

--- a/androidbrowserhelper/src/main/res/values/strings.xml
+++ b/androidbrowserhelper/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="no_provider_toast">Please install Chrome Stable 72 or later.</string>
     <string name="manage_space_not_supported_toast">This app\'s data is stored in %1$s.</string>
     <string name="manage_space_no_data_toast">This app holds no browsing data.</string>
+    <string name="provider_unavailable_title">App Unavailable</string>
+    <string name="provider_unavailable_message">This app is unavailable because %1$s is blocked</string>
+    <string name="view_app_limits">View app limits</string>
 </resources>

--- a/androidbrowserhelper/src/main/res/values/strings.xml
+++ b/androidbrowserhelper/src/main/res/values/strings.xml
@@ -8,5 +8,4 @@
     <string name="provider_unavailable_message">This app is unavailable because %1$s is blocked</string>
     <string name="provider_unavailable_button_ok">OK</string>
     <string name="provider_unavailable_default_browser">Chrome</string>
-    <string name="view_app_limits">View app limits</string>
 </resources>

--- a/androidbrowserhelper/src/main/res/values/strings.xml
+++ b/androidbrowserhelper/src/main/res/values/strings.xml
@@ -6,5 +6,7 @@
     <string name="manage_space_no_data_toast">This app holds no browsing data.</string>
     <string name="provider_unavailable_title">App Unavailable</string>
     <string name="provider_unavailable_message">This app is unavailable because %1$s is blocked</string>
+    <string name="provider_unavailable_button_ok">OK</string>
+    <string name="provider_unavailable_default_browser">Chrome</string>
     <string name="view_app_limits">View app limits</string>
 </resources>


### PR DESCRIPTION
This applies when there is no package available for any of the options (browser, trusted web activity, or custom tab). When the custom tab fallback itself fails because there is no provider available, there is currently an exception thrown somewhere in the Android package management code. Visually, the user sees a window open, there's some flickering from lots of retries to launch a custom tab, and then it gives up and fails.

The most prominent case for this is when Android's parental controls are active and they have blocked Chrome (or whichever browser is installed on the device). To make this case clearer to the user, this introduces a dialogue telling the user that their browser is blocked and provides a link to parental controls in settings. There are admittedly some use cases where this can happen for reasons other than parental controls, but this was deemed not worth the complexity since this is a short term solution for a very niche case.