### PR TITLE
Add explicit browser targeting

### DIFF
--- a/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/TwaLauncherTest.java
+++ b/androidbrowserhelper/src/androidTest/java/com/google/androidbrowserhelper/trusted/TwaLauncherTest.java
@@ -308,8 +308,34 @@ public class TwaLauncherTest {
                 mCustomTabsCallback, null, null, TwaLauncher.CCT_FALLBACK_STRATEGY));
 
         InstrumentationRegistry.getInstrumentation().waitForIdleSync();
-        verify(mockStrategy).show(any());
+        verify(mockStrategy).show(any(), eq(true), any());
         assertNotNull(launcher);
+    }
+
+    @Test
+    public void blockedDialogFallbackStrategy_showsBrowserUnavailableDialog() throws Exception {
+        TwaLauncher.BrowserUnavailableDialogStrategy mockStrategy =
+                mock(TwaLauncher.BrowserUnavailableDialogStrategy.class);
+        TwaLauncher.setDialogStrategyForTesting(mockStrategy);
+
+        TwaLauncher.FallbackStrategy strategy = TwaLauncher.getBlockedDialogFallbackStrategy("MyBrowser");
+        mActivity.runOnUiThread(() -> strategy.launch(mActivity, makeBuilder(), null, null));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        verify(mockStrategy).show(any(), eq(false), eq("MyBrowser"));
+    }
+
+    @Test
+    public void blockedDialogFallbackStrategy_showsBrowserUnavailableDialog_emptyName() throws Exception {
+        TwaLauncher.BrowserUnavailableDialogStrategy mockStrategy =
+                mock(TwaLauncher.BrowserUnavailableDialogStrategy.class);
+        TwaLauncher.setDialogStrategyForTesting(mockStrategy);
+
+        TwaLauncher.FallbackStrategy strategy = TwaLauncher.getBlockedDialogFallbackStrategy(null);
+        mActivity.runOnUiThread(() -> strategy.launch(mActivity, makeBuilder(), null, null));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        verify(mockStrategy).show(any(), eq(false), eq(null));
     }
 
     private TrustedWebActivityIntentBuilder makeBuilder() {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -276,7 +276,7 @@ public class LauncherActivity extends Activity {
     }
 
     protected TwaLauncher createTwaLauncher() {
-        return new TwaLauncher(this, null, SessionStore.makeSessionId(getTaskId()),
+        return new TwaLauncher(this, mMetadata.launchingBrowser, SessionStore.makeSessionId(getTaskId()),
                 new SharedPreferencesTokenStore(this));
     }
 
@@ -475,6 +475,9 @@ public class LauncherActivity extends Activity {
      * fallback implementation ot starting a native Activity.
      */
     protected TwaLauncher.FallbackStrategy getFallbackStrategy() {
+        if (mMetadata.launchingBrowser != null) {
+            return TwaLauncher.getBlockedDialogFallbackStrategy(mMetadata.launchingBrowserName);
+        }
         if (FALLBACK_TYPE_WEBVIEW.equalsIgnoreCase(mMetadata.fallbackStrategyType)) {
             return TwaLauncher.WEBVIEW_FALLBACK_STRATEGY;
         }

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivityMetadata.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivityMetadata.java
@@ -183,6 +183,18 @@ public class LauncherActivityMetadata {
     private static final String METADATA_START_CHROME_BEFORE_ANIMATION_COMPLETE =
             "android.support.customtabs.trusted.START_CHROME_BEFORE_ANIMATION_COMPLETE";
 
+    /**
+     * The package name of the browser that the TWA should be launched in.
+     */
+    private static final String METADATA_LAUNCHING_BROWSER =
+            "android.support.customtabs.trusted.LAUNCHING_BROWSER";
+
+    /**
+     * The human-readable name of the browser that the TWA should be launched in.
+     */
+    private static final String METADATA_LAUNCHING_BROWSER_NAME =
+            "android.support.customtabs.trusted.LAUNCHING_BROWSER_NAME";
+
     private final static int DEFAULT_COLOR_ID = android.R.color.white;
     private final static int DEFAULT_DIVIDER_COLOR_ID = android.R.color.transparent;
 
@@ -206,6 +218,8 @@ public class LauncherActivityMetadata {
     @Nullable public final String fileHandlingActionUrl;
     @LaunchHandlerClientMode.ClientMode public final int launchHandlerClientMode;
     public final boolean startChromeBeforeAnimationComplete;
+    @Nullable public final String launchingBrowser;
+    @Nullable public final String launchingBrowserName;
 
     private LauncherActivityMetadata(@NonNull Bundle metaData, @NonNull Resources resources) {
         defaultUrl = metaData.getString(METADATA_DEFAULT_URL);
@@ -243,6 +257,8 @@ public class LauncherActivityMetadata {
                 metaData.getString(LAUNCH_HANDLER_CLIENT_MODE_METADATA_NAME));
         startChromeBeforeAnimationComplete =
                 metaData.getBoolean(METADATA_START_CHROME_BEFORE_ANIMATION_COMPLETE, true);
+        launchingBrowser = metaData.getString(METADATA_LAUNCHING_BROWSER);
+        launchingBrowserName = metaData.getString(METADATA_LAUNCHING_BROWSER_NAME);
     }
 
     private @ScreenOrientation.LockType int getOrientation(String orientation) {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.google.androidbrowserhelper.trusted.splashscreens.SplashScreenStrategy;
@@ -68,7 +69,7 @@ public class TwaLauncher {
      * facilitate unit testing.
      */
     public interface BrowserUnavailableDialogStrategy {
-        void show(Activity activity);
+        void show(Activity activity, boolean queryInstalledBrowsers, @Nullable String browserName);
     }
 
     private static BrowserUnavailableDialogStrategy sDialogStrategy =
@@ -80,6 +81,19 @@ public class TwaLauncher {
         sDialogStrategy = strategy;
     }
 
+    /**
+     * Returns a FallbackStrategy that shows the browser unavailable dialog with the specified browser name.
+     */
+    public static FallbackStrategy getBlockedDialogFallbackStrategy(@Nullable String browserName) {
+        return (context, twaBuilder, providerPackage, completionCallback) -> {
+            if (context instanceof Activity) {
+                sDialogStrategy.show((Activity) context, false, browserName);
+            } else {
+                Log.e(TAG, "Cannot show browser unavailable dialog without an Activity context.");
+            }
+        };
+    }
+
     public static final FallbackStrategy CCT_FALLBACK_STRATEGY =
             (context, twaBuilder, providerPackage, completionCallback) -> {
         if (providerPackage == null) {
@@ -87,7 +101,7 @@ public class TwaLauncher {
         }
         if (providerPackage == null) {
             if (context instanceof Activity) {
-                sDialogStrategy.show((Activity) context);
+                sDialogStrategy.show((Activity) context, true, null);
             } else {
                 Log.e(TAG, "Cannot show browser unavailable dialog without an Activity context.");
             }
@@ -305,8 +319,11 @@ public class TwaLauncher {
 
         mServiceConnection.setSessionCreationRunnables(
                 onSessionCreatedRunnable, onSessionCreationFailedRunnable);
-        CustomTabsClient.bindCustomTabsServicePreservePriority(
+        boolean bound = CustomTabsClient.bindCustomTabsServicePreservePriority(
                 mContext, mProviderPackage, mServiceConnection);
+        if (!bound) {
+            onSessionCreationFailedRunnable.run();
+        }
     }
 
     private void launchWhenSessionEstablished(TrustedWebActivityIntentBuilder twaBuilder,
@@ -381,30 +398,40 @@ public class TwaLauncher {
      * Shows a dialog explaining that no browser is available to open the URL.
      *
      * @param activity The {@link Activity} used to show the dialog.
+     * @param queryInstalledBrowsers Whether to query the system for installed browsers to determine the browser name.
+     * @param browserName The name of the browser to display, if known.
      */
-    private static void showBrowserUnavailableDialog(Activity activity) {
-        PackageManager pm = activity.getPackageManager();
+    private static void showBrowserUnavailableDialog(Activity activity, boolean queryInstalledBrowsers, @Nullable String browserName) {
+        if (queryInstalledBrowsers) {
+            PackageManager pm = activity.getPackageManager();
 
-        // Query for all browsers that can handle a standard URL. This allows us to find the
-        // user's preferred browser to provide a helpful name in the dialog.
-        Intent queryBrowsersIntent = new Intent()
-                .setAction(Intent.ACTION_VIEW)
-                .addCategory(Intent.CATEGORY_BROWSABLE)
-                .setData(Uri.fromParts("http", "", null));
+            // Query for all browsers that can handle a standard URL. This allows us to find the
+            // user's preferred browser to provide a helpful name in the dialog.
+            Intent queryBrowsersIntent = new Intent()
+                    .setAction(Intent.ACTION_VIEW)
+                    .addCategory(Intent.CATEGORY_BROWSABLE)
+                    .setData(Uri.fromParts("http", "", null));
 
-        List<ResolveInfo> allBrowsers = pm.queryIntentActivities(queryBrowsersIntent,
-                PackageManager.MATCH_DEFAULT_ONLY | PackageManager.MATCH_UNINSTALLED_PACKAGES);
+            List<ResolveInfo> allBrowsers = pm.queryIntentActivities(queryBrowsersIntent,
+                    PackageManager.MATCH_DEFAULT_ONLY | PackageManager.MATCH_UNINSTALLED_PACKAGES);
 
-        String browserName = activity.getString(R.string.provider_unavailable_default_browser);
-        if (!allBrowsers.isEmpty()) {
-            // The list is ordered from best to worst match, so we pick the first one.
-            browserName = allBrowsers.get(0).loadLabel(pm).toString();
+            browserName = activity.getString(R.string.provider_unavailable_default_browser);
+            if (!allBrowsers.isEmpty()) {
+                // The list is ordered from best to worst match, so we pick the first one.
+                browserName = allBrowsers.get(0).loadLabel(pm).toString();
+            }
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        builder.setTitle(R.string.provider_unavailable_title)
-                .setMessage(activity.getString(R.string.provider_unavailable_message, browserName))
-                .setPositiveButton(R.string.provider_unavailable_button_ok, (dialog, which) -> dialog.dismiss())
+        builder.setTitle(R.string.provider_unavailable_title);
+
+        if (TextUtils.isEmpty(browserName)) {
+            builder.setMessage(activity.getString(R.string.provider_unavailable_fallback_message));
+        } else {
+            builder.setMessage(activity.getString(R.string.provider_unavailable_message, browserName));
+        }
+
+        builder.setPositiveButton(R.string.provider_unavailable_button_ok, (dialog, which) -> dialog.dismiss())
                 .setCancelable(true);
         builder.setOnDismissListener(dialog -> activity.finish());
         builder.show();

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -15,8 +15,9 @@
 package com.google.androidbrowserhelper.trusted;
 
 
+import static androidx.appcompat.R.style.Theme_AppCompat_DayNight_Dialog_Alert;
+
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
@@ -29,6 +30,8 @@ import android.util.Log;
 
 import com.google.androidbrowserhelper.trusted.splashscreens.SplashScreenStrategy;
 
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabsCallback;
 import androidx.browser.customtabs.CustomTabsClient;
@@ -422,7 +425,8 @@ public class TwaLauncher {
             }
         }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        AlertDialog.Builder builder = new AlertDialog.Builder(
+                new ContextThemeWrapper(activity, Theme_AppCompat_DayNight_Dialog_Alert));
         builder.setTitle(R.string.provider_unavailable_title);
 
         if (TextUtils.isEmpty(browserName)) {

--- a/androidbrowserhelper/src/main/res/values/strings.xml
+++ b/androidbrowserhelper/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="manage_space_no_data_toast">This app holds no browsing data.</string>
     <string name="provider_unavailable_title">App Unavailable</string>
     <string name="provider_unavailable_message">This app is unavailable because %1$s is blocked</string>
+    <string name="provider_unavailable_fallback_message">This app is unavailable.</string>
     <string name="provider_unavailable_button_ok">OK</string>
     <string name="provider_unavailable_default_browser">Chrome</string>
 </resources>


### PR DESCRIPTION
- Parse `LAUNCHING_BROWSER` and `LAUNCHING_BROWSER_NAME` from AndroidManifest metadata.
- Introduce `getBlockedDialogFallbackStrategy` to present an alert dialog when targeted browsers are unavailable.
- Fix missing styling from the Browser Unavailable dialog