### PR TITLE
Expose CustomTabsSession on TwaLauncher and LauncherActivity

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -30,6 +30,7 @@ import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsCallback;
 import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsSession;
 import androidx.browser.trusted.FileHandlingData;
 import androidx.browser.trusted.TrustedWebActivityDisplayMode;
 import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
@@ -278,6 +279,19 @@ public class LauncherActivity extends Activity {
     protected TwaLauncher createTwaLauncher() {
         return new TwaLauncher(this, mMetadata.launchingBrowser, SessionStore.makeSessionId(getTaskId()),
                 new SharedPreferencesTokenStore(this));
+    }
+
+    /**
+     * Returns the current CustomTabsSession from the TwaLauncher.
+     *
+     * The session becomes available after the TWA is launched and the service connects.
+     * Can be used for advanced features like PostMessage.
+     *
+     * @return The active CustomTabsSession, or null if TWA hasn't launched yet or service disconnected
+     */
+    @Nullable
+    protected CustomTabsSession getCustomTabsSession() {
+        return mTwaLauncher != null ? mTwaLauncher.getSession() : null;
     }
 
     private boolean splashScreenNeeded() {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivity.java
@@ -30,6 +30,7 @@ import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsCallback;
 import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsSession;
 import androidx.browser.trusted.FileHandlingData;
 import androidx.browser.trusted.TrustedWebActivityDisplayMode;
 import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
@@ -280,6 +281,19 @@ public class LauncherActivity extends Activity {
     protected TwaLauncher createTwaLauncher() {
         return new TwaLauncher(this, mMetadata.launchingBrowser, SessionStore.makeSessionId(getTaskId()),
                 new SharedPreferencesTokenStore(this));
+    }
+
+    /**
+     * Returns the current CustomTabsSession from the TwaLauncher.
+     *
+     * The session becomes available after the TWA is launched and the service connects.
+     * Can be used for advanced features like PostMessage.
+     *
+     * @return The active CustomTabsSession, or null if TWA hasn't launched yet or service disconnected
+     */
+    @Nullable
+    protected CustomTabsSession getCustomTabsSession() {
+        return mTwaLauncher != null ? mTwaLauncher.getSession() : null;
     }
 
     private boolean splashScreenNeeded() {

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -389,6 +389,20 @@ public class TwaLauncher {
     }
 
     /**
+     * Returns the current CustomTabsSession, if available.
+     *
+     * This is useful for advanced use cases like PostMessage that require direct
+     * session access. The session becomes available after the service connects and
+     * may become null if the service disconnects.
+     *
+     * @return The active CustomTabsSession, or null if not yet established or disconnected
+     */
+    @Nullable
+    public CustomTabsSession getSession() {
+        return mSession;
+    }
+
+    /**
      * Sets the timestamp (in SystemClock.uptimeMillis()) when the TWA launcher
      * activity was created. This timestamp is used to report the full startup
      * duration to the browser.

--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/TwaLauncher.java
@@ -401,6 +401,20 @@ public class TwaLauncher {
     }
 
     /**
+     * Returns the current CustomTabsSession, if available.
+     *
+     * This is useful for advanced use cases like PostMessage that require direct
+     * session access. The session becomes available after the service connects and
+     * may become null if the service disconnects.
+     *
+     * @return The active CustomTabsSession, or null if not yet established or disconnected
+     */
+    @Nullable
+    public CustomTabsSession getSession() {
+        return mSession;
+    }
+
+    /**
      * Sets the timestamp (in SystemClock.uptimeMillis()) when the TWA launcher
      * activity was created. This timestamp is used to report the full startup
      * duration to the browser.


### PR DESCRIPTION
## Summary
Adds two `@Nullable` read-only accessors over fields that already exist:

- `TwaLauncher#getSession()` (public)
- `LauncherActivity#getCustomTabsSession()` (protected)

No behavior change for callers that don't use them.

## Motivation
Apps that subclass `LauncherActivity` (e.g. anything generated by Bubblewrap) can't reach the `CustomTabsSession` that `TwaLauncher` constructs internally. Since Chrome 115 enabled `postMessage` in TWAs, that session is the only entry point to `requestPostMessageChannel` / `postMessage`, so the high-level launcher is currently incompatible with PostMessage.

The `demos/twa-post-message` sample added in #429 builds its own session and does not extend `LauncherActivity`, so it doesn't translate to the Bubblewrap launcher path. In the wild this is worked around with reflection on `mSession` or by spinning up a parallel `CustomTabsServiceConnection` and relaunching the TWA — both fragile.

## Lifecycle
The session is established asynchronously in `onCustomTabsServiceConnected` and cleared in `onServiceDisconnected` / `destroy()`. Both getters are `@Nullable` and the Javadoc tells callers to guard.

## Usage
With this in place, a subclass can wire PostMessage on the existing `getCustomTabsCallback()` hook:

```java
@Override
protected CustomTabsCallback getCustomTabsCallback() {
    return new CustomTabsCallback() {
        @Override public void onNavigationEvent(int event, Bundle extras) {
            if (event != NAVIGATION_FINISHED) return;
            CustomTabsSession s = getCustomTabsSession();
            if (s != null) s.requestPostMessageChannel(source, target, new Bundle());
        }
        @Override public void onPostMessage(@NonNull String msg, @Nullable Bundle extras) {
            CustomTabsSession s = getCustomTabsSession();
            if (s != null) s.postMessage("pong", null);
        }
    };
}
```

Verified end-to-end in a Bubblewrap-generated production app.

## Scope
- No `postMessage` helpers or callback wrappers — those belong in `androidx.browser.customtabs`.
- No new fields, lifecycle changes, threads, or dependencies.
- No change to session creation timing or `DEFAULT_SESSION_ID`.

Closes #472. Closes #510. Refs GoogleChromeLabs/bubblewrap#954.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
