### PR TITLE
Configure PendingPurchasesParams for one-time products

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -27,6 +27,7 @@ import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeParams;
 import com.android.billingclient.api.ConsumeResponseListener;
+import com.android.billingclient.api.PendingPurchasesParams;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchaseHistoryResponseListener;
 import com.android.billingclient.api.PurchasesResponseListener;
@@ -63,7 +64,9 @@ public class PlayBillingWrapper implements BillingWrapper {
         mClient = BillingClient
                 .newBuilder(context)
                 .setListener(mPurchaseUpdateListener)
-                .enablePendingPurchases()
+                .enablePendingPurchases(PendingPurchasesParams.newBuilder()
+                        .enableOneTimeProducts()
+                        .build())
                 .build();
     }
 


### PR DESCRIPTION
Configured the Play Billing Wrapper's `BillingClient` to support one-time pending purchases while ensuring prepaid plans remain disabled.