### PR TITLE
Migrate notification channels for TWAs to reuse high priority if already installed

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/NotificationUtils.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/NotificationUtils.java
@@ -48,7 +48,7 @@ public class NotificationUtils {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return true;
 
         NotificationChannel channel =
-                    NotificationManagerCompat.from(context).getNotificationChannel(channelNameToId(channelName));
+                    NotificationManagerCompat.from(context).getNotificationChannel(channelNameToId(context, channelName));
         return channel == null || channel.getImportance() != NotificationManager.IMPORTANCE_NONE;
     }
 
@@ -111,18 +111,26 @@ public class NotificationUtils {
      * from manifest metadata.
      */
     public static void createNotificationChannel(Context context, String channelName) {
-        createNotificationChannel(context, channelName, getNotificationImportance(context));
+        createNotificationChannelAndMaybeDeleteOldOne(context, channelName, getNotificationImportance(context));
     }
 
     /**
-     * Creates a notification channel using the given channel name and explicit importance level.
+     * Creates a notification channel and cleans up the obsolete one.
      */
-    public static void createNotificationChannel(Context context, String channelName, int importance) {
+    static void createNotificationChannelAndMaybeDeleteOldOne(Context context, String channelName, int importance) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
 
-        NotificationChannel channel = new NotificationChannel(channelNameToId(channelName),
+        NotificationChannel channel = new NotificationChannel(channelNameToId(context, channelName),
                 channelName, importance);
         NotificationManagerCompat.from(context).createNotificationChannel(channel);
+
+        // Clean up the obsolete channel to prevent duplicates in system settings.
+        String baseId = channelName.toLowerCase(Locale.ROOT).replace(' ', '_');
+        String obsoleteChannelId = shouldUseHighPriorityNotifications(context)
+                ? baseId + "_channel_id"
+                : baseId + "_channel_id_high_pri";
+
+        NotificationManagerCompat.from(context).deleteNotificationChannel(obsoleteChannelId);
     }
 
     /**
@@ -130,7 +138,10 @@ public class NotificationUtils {
      * TODO: Remove this when we can use the method defined in AndroidX instead.
      */
     @VisibleForTesting
-    static String channelNameToId(String name) {
-        return name.toLowerCase(Locale.ROOT).replace(' ', '_') + "_channel_id";
+    static String channelNameToId(Context context, String name) {
+        String baseId = name.toLowerCase(Locale.ROOT).replace(' ', '_');
+        return shouldUseHighPriorityNotifications(context)
+                ? baseId + "_channel_id_high_pri"
+                : baseId + "_channel_id";
     }
 }

--- a/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/NotificationUtilsParameterizedTest.java
+++ b/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/NotificationUtilsParameterizedTest.java
@@ -16,6 +16,7 @@ package com.google.androidbrowserhelper.trusted;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.NotificationChannel;
@@ -163,10 +164,21 @@ public class NotificationUtilsParameterizedTest {
     public void createNotificationChannel_resolvesImportanceCorrectly() {
         NotificationUtils.createNotificationChannel(mContext, CHANNEL_NAME);
 
-        NotificationChannel channel = mNotificationManager.getNotificationChannel(EXPECTED_CHANNEL_ID);
+        String expectedChannelId = mExpectedShouldUseHighPriority
+                ? "general_notifications_channel_id_high_pri"
+                : "general_notifications_channel_id";
+
+        NotificationChannel channel = mNotificationManager.getNotificationChannel(expectedChannelId);
         assertNotNull(channel);
         assertEquals(CHANNEL_NAME, channel.getName().toString());
         assertEquals(mExpectedImportance, channel.getImportance());
+
+        String obsoleteChannelId = mExpectedShouldUseHighPriority
+                ? "general_notifications_channel_id"
+                : "general_notifications_channel_id_high_pri";
+
+        NotificationChannel obsoleteChannel = mNotificationManager.getNotificationChannel(obsoleteChannelId);
+        assertNull(obsoleteChannel);
     }
 
     private void setServiceMetadata(String key, Object value) {

--- a/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/NotificationUtilsTest.java
+++ b/androidbrowserhelper/src/test/java/com/google/androidbrowserhelper/trusted/NotificationUtilsTest.java
@@ -58,21 +58,11 @@ public class NotificationUtilsTest {
     @Test
     public void channelNameToId_replacesSpacesAndAppendsSuffix() {
         assertEquals("general_notifications_channel_id",
-                NotificationUtils.channelNameToId("General Notifications"));
+                NotificationUtils.channelNameToId(mContext, "General Notifications"));
         assertEquals("chat_channel_id",
-                NotificationUtils.channelNameToId("Chat"));
+                NotificationUtils.channelNameToId(mContext, "Chat"));
         assertEquals("test_channel_name_channel_id",
-                NotificationUtils.channelNameToId("Test Channel Name"));
-    }
-
-    @Test
-    public void createNotificationChannel_explicitImportanceOverridesMetadata() {
-        NotificationUtils.createNotificationChannel(mContext, CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW);
-
-        NotificationChannel channel = mNotificationManager.getNotificationChannel(EXPECTED_CHANNEL_ID);
-        assertNotNull(channel);
-        assertEquals(CHANNEL_NAME, channel.getName().toString());
-        assertEquals(NotificationManager.IMPORTANCE_LOW, channel.getImportance());
+                NotificationUtils.channelNameToId(mContext, "Test Channel Name"));
     }
 
     @Test


### PR DESCRIPTION
If a TWA is already installed, then just changing the priority of the notifications will not "update" the existing notification channels, even if the manifest field is set.

This PR fixes that by doing a "migration", by ensuring that if `androidx.browser.trusted.USE_HIGH_PRI_NOTIFICATIONS` is set to true for existing TWAs, a new channelId is used, which retriggers notifications permissions and notification channel
creation. This helps fully solve #607 .