### PR TITLE
Ensure notification popups do not lag behind notification sounds, mimicing "appear as popup" on the settings

### DIFF
--- a/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/DelegationService.java
+++ b/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/DelegationService.java
@@ -111,6 +111,9 @@ public class DelegationService extends TrustedWebActivityService {
 
             Notification.Builder builder = Notification.Builder.recoverBuilder(this, notification);
             builder.setChannelId(channelId);
+            if (notification.getGroupAlertBehavior() == Notification.GROUP_ALERT_SUMMARY) {
+                builder.setGroupAlertBehavior(Notification.GROUP_ALERT_ALL);
+            }
             notification = builder.build();
         }
         notificationManager.notify(platformTag, platformId, notification);


### PR DESCRIPTION
Most notifications have the group alert behavior set to `GROUP_ALERT_SUMMARY`, which hides the popups behind the sound of the notification coming in the shade to show a single notification popup, giving the "feeling" that the notification is lagging.

Fix that by ensuring that `GROUP_ALERT_ALL` for TWA notifications so that popups appear instantly, bringing behavior closer to other desktop platforms.