### PR TITLE
Add support for obfuscatedAccountId in payment flow

### DIFF
--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MethodData.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/MethodData.java
@@ -74,13 +74,18 @@ public class MethodData {
     @Nullable public final String purchaseToken;
     @Nullable public final Integer replacementMode;
 
+    // Optional account identifier forwarded to Play Billing's setObfuscatedAccountId().
+    @Nullable public final String obfuscatedAccountId;
+
     private MethodData(String sku, boolean isPriceChangeConfirmation, @Nullable String oldSku,
-                       @Nullable String purchaseToken, @Nullable Integer replacementMode) {
+                       @Nullable String purchaseToken, @Nullable Integer replacementMode,
+                       @Nullable String obfuscatedAccountId) {
         this.sku = sku;
         this.isPriceChangeConfirmation = isPriceChangeConfirmation;
         this.oldSku = oldSku;
         this.purchaseToken = purchaseToken;
         this.replacementMode = replacementMode;
+        this.obfuscatedAccountId = obfuscatedAccountId;
     }
 
     @Nullable
@@ -104,6 +109,7 @@ public class MethodData {
 
         String oldSku = getString(dataObject, "oldSku");
         String purchaseToken = getString(dataObject, "purchaseToken");
+        String obfuscatedAccountId = getString(dataObject, "obfuscatedAccountId");
 
         Integer replacementMode = getReplacementMode(dataObject);
         if (replacementMode == null) {
@@ -113,7 +119,8 @@ public class MethodData {
             }
         }
 
-        return new MethodData(sku, isPriceChangeConfirmation, oldSku, purchaseToken, replacementMode);
+        return new MethodData(sku, isPriceChangeConfirmation, oldSku, purchaseToken, replacementMode,
+                obfuscatedAccountId);
     }
 
     /**

--- a/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
+++ b/playbilling/src/main/java/com/google/androidbrowserhelper/playbilling/provider/PlayBillingWrapper.java
@@ -153,6 +153,10 @@ public class PlayBillingWrapper implements BillingWrapper {
         BillingFlowParams.Builder builder = BillingFlowParams.newBuilder()
             .setProductDetailsParamsList(productDetailsParamsList);
 
+        if (methodData.obfuscatedAccountId != null) {
+            builder.setObfuscatedAccountId(methodData.obfuscatedAccountId);
+        }
+
         if (methodData.replacementMode != null) {
             subUpdateParamsBuilder.setSubscriptionReplacementMode(methodData.replacementMode);
         }

--- a/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/provider/MethodDataTest.java
+++ b/playbilling/src/test/java/com/google/androidbrowserhelper/playbilling/provider/MethodDataTest.java
@@ -92,6 +92,23 @@ public class MethodDataTest {
     }
 
     @Test
+    public void fromJson_obfuscatedAccountId() {
+        String json = "{ 'sku' = 'mySku', 'obfuscatedAccountId' = 'obfuscatedId123' }"
+                .replace('\'', '\"');
+        MethodData data = MethodData.fromJson(json);
+
+        assertEquals("obfuscatedId123", data.obfuscatedAccountId);
+    }
+
+    @Test
+    public void fromJson_obfuscatedAccountId_default() {
+        String json = "{ 'sku' = 'mySku' }".replace('\'', '\"');
+        MethodData data = MethodData.fromJson(json);
+
+        assertNull(data.obfuscatedAccountId);
+    }
+
+    @Test
     public void fromJson_replacementMode() {
         replacementMode("deferred", ReplacementMode.DEFERRED);
         replacementMode("chargeProratedPrice",


### PR DESCRIPTION
Fixes #583

Adds support for an optional `obfuscatedAccountId` field in the PaymentRequest method data, forwarded to `BillingFlowParams.setObfuscatedAccountId()`:

```js
const supportedInstruments = [{
    supportedMethods: 'https://play.google.com/billing',
    data: {
        sku: 'my_sku',
        obfuscatedAccountId: userAccountObfuscatedId,
    }
}];
```

This lets developers correlate purchases reported by Google Play RTDN webhooks with their own user accounts, without depending on client-side confirmation succeeding.

The field is optional, so existing integrations are unaffected. Includes unit tests in `MethodDataTest`.
